### PR TITLE
Add web platform support with no-op implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A cross-platform SIP (Session Initiation Protocol) client built for Flutter using C/Rust FFI.
 
+Web is supported as a compatibility target only. Since PJSIP cannot be
+compiled for web, the public SIP APIs are no-ops when running in a browser.
+
 ## Features
 
 - SIP registration and call handling

--- a/example/lib/call_status_card.dart
+++ b/example/lib/call_status_card.dart
@@ -1,18 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_rust_sip/flutter_rust_sip.dart'
-    show
-        CallInfo,
-        CallState,
-        CallState_Calling,
-        CallState_Connecting,
-        CallState_Confirmed;
+    show CallInfo, CallState, CallState_Calling, CallState_Connecting, CallState_Confirmed;
 import 'package:flutter_rust_sip/sip_service.dart';
 
 extension CallInfoExtension on CallState {
   bool get isActive {
-    return this is CallState_Calling ||
-        this is CallState_Connecting ||
-        this is CallState_Confirmed;
+    return this is CallState_Calling || this is CallState_Connecting || this is CallState_Confirmed;
   }
 }
 
@@ -21,11 +14,7 @@ class CallStatusCard extends StatelessWidget {
   final CallInfo callInfo;
   final void Function(int)? onHangup;
 
-  const CallStatusCard(
-      {super.key,
-      required this.service,
-      required this.callInfo,
-      this.onHangup});
+  const CallStatusCard({super.key, required this.service, required this.callInfo, this.onHangup});
 
   @override
   Widget build(BuildContext context) {
@@ -64,8 +53,7 @@ class CallStatusCard extends StatelessWidget {
                 Text(
                   callInfo.state.toString(),
                   style: TextStyle(
-                    color:
-                        callInfo.state.isActive ? Colors.green : Colors.black54,
+                    color: callInfo.state.isActive ? Colors.green : Colors.black54,
                     fontSize: 16,
                   ),
                 ),
@@ -92,8 +80,7 @@ class CallStatusCard extends StatelessWidget {
               icon: const Icon(Icons.call_end),
               label: const Text('Hang Up'),
               style: ElevatedButton.styleFrom(
-                backgroundColor:
-                    callInfo.state.isActive ? Colors.red : Colors.grey,
+                backgroundColor: callInfo.state.isActive ? Colors.red : Colors.grey,
               ),
             ),
           ],

--- a/example/lib/call_status_card.dart
+++ b/example/lib/call_status_card.dart
@@ -21,7 +21,11 @@ class CallStatusCard extends StatelessWidget {
   final CallInfo callInfo;
   final void Function(int)? onHangup;
 
-  const CallStatusCard({super.key, required this.service, required this.callInfo, this.onHangup});
+  const CallStatusCard(
+      {super.key,
+      required this.service,
+      required this.callInfo,
+      this.onHangup});
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/call_widget.dart
+++ b/example/lib/call_widget.dart
@@ -39,7 +39,7 @@ class _SIPServiceWidgetState extends State<SIPServiceWidget> {
         CallerWidget(
           service: widget.service,
         ),
-        Flexible( 
+        Flexible(
           child: Wrap(
             children: activeCalls.entries
                 .map((e) => CallStatusCard(

--- a/example/lib/di.dart
+++ b/example/lib/di.dart
@@ -4,8 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_rust_sip/rust/core/types.dart' show OnIncommingCall;
 import 'package:flutter_rust_sip/sip_service.dart';
 
-final sipServiceProvider =
-    FutureProvider<SIPService>((ref) async {
+final sipServiceProvider = FutureProvider<SIPService>((ref) async {
   try {
     final service = await SIPService.init(
         localPort: 5062, incomingCallStrategy: OnIncommingCall.autoAnswer);

--- a/example/lib/di.dart
+++ b/example/lib/di.dart
@@ -6,8 +6,8 @@ import 'package:flutter_rust_sip/sip_service.dart';
 
 final sipServiceProvider = FutureProvider<SIPService>((ref) async {
   try {
-    final service = await SIPService.init(
-        localPort: 5062, incomingCallStrategy: OnIncommingCall.autoAnswer);
+    final service =
+        await SIPService.init(localPort: 5062, incomingCallStrategy: OnIncommingCall.autoAnswer);
     return service;
   } catch (e) {
     // Return a failed future instead of crashing

--- a/example/lib/login_widget.dart
+++ b/example/lib/login_widget.dart
@@ -10,10 +10,14 @@ class LoginWidget extends ConsumerStatefulWidget {
 }
 
 class _LoginWidgetState extends ConsumerState<LoginWidget> {
-  final TextEditingController _usernameController = TextEditingController()..text = 'client';
-  final TextEditingController _passwordController = TextEditingController()..text = 'clientpwd';
-  final TextEditingController _sipServerUrlController = TextEditingController()..text = 'localhost';
-  final TextEditingController _portController = TextEditingController()..text = '5060';
+  final TextEditingController _usernameController = TextEditingController()
+    ..text = 'client';
+  final TextEditingController _passwordController = TextEditingController()
+    ..text = 'clientpwd';
+  final TextEditingController _sipServerUrlController = TextEditingController()
+    ..text = 'localhost';
+  final TextEditingController _portController = TextEditingController()
+    ..text = '5060';
   String registrationStatusText = 'Not Registered yet';
 
   @override
@@ -31,13 +35,13 @@ class _LoginWidgetState extends ConsumerState<LoginWidget> {
       final status = statusAsync.value;
       setState(() {
         registrationStatusText = switch (status) {
-        200 => 'SIP Account Registered Successfully',
-        -1 => 'Not Registered yet (Error code: $status)',
-        _ => 'Registration failed... (Status code: $status)',
-      };
+          200 => 'SIP Account Registered Successfully',
+          -1 => 'Not Registered yet (Error code: $status)',
+          _ => 'Registration failed... (Status code: $status)',
+        };
       });
     });
-    
+
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -92,8 +96,8 @@ class _LoginWidgetState extends ConsumerState<LoginWidget> {
                     final service = await ref.read(sipServiceProvider.future);
                     service
                         .registerAccount(
-                        uri: _sipServerUrlController.text,
-                        username: _usernameController.text,
+                            uri: _sipServerUrlController.text,
+                            username: _usernameController.text,
                             password: _passwordController.text)
                         .then((accountId) {
                       debugPrint('Account registered with ID: $accountId');

--- a/example/lib/login_widget.dart
+++ b/example/lib/login_widget.dart
@@ -10,14 +10,10 @@ class LoginWidget extends ConsumerStatefulWidget {
 }
 
 class _LoginWidgetState extends ConsumerState<LoginWidget> {
-  final TextEditingController _usernameController = TextEditingController()
-    ..text = 'client';
-  final TextEditingController _passwordController = TextEditingController()
-    ..text = 'clientpwd';
-  final TextEditingController _sipServerUrlController = TextEditingController()
-    ..text = 'localhost';
-  final TextEditingController _portController = TextEditingController()
-    ..text = '5060';
+  final TextEditingController _usernameController = TextEditingController()..text = 'client';
+  final TextEditingController _passwordController = TextEditingController()..text = 'clientpwd';
+  final TextEditingController _sipServerUrlController = TextEditingController()..text = 'localhost';
+  final TextEditingController _portController = TextEditingController()..text = '5060';
   String registrationStatusText = 'Not Registered yet';
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -38,4 +38,3 @@ class MyApp extends StatelessWidget {
     );
   }
 }
-

--- a/example/lib/sip_widget_builder.dart
+++ b/example/lib/sip_widget_builder.dart
@@ -15,7 +15,8 @@ class SIPWidgetBuilder extends ConsumerWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         Center(
-          child: service.when(data: (service) {
+          child: service.when(
+            data: (service) {
               return Column(
                 children: [
                   const Text('SIP Service Initialized'),
@@ -25,11 +26,11 @@ class SIPWidgetBuilder extends ConsumerWidget {
                     const Text('SIP Service not registered yet'),
                 ],
               );
-          }, error: (error, _) {
-            return Text('Error initializing SIP Service: $error');
             },
-            loading: () =>
-                const CircularProgressIndicator(),
+            error: (error, _) {
+              return Text('Error initializing SIP Service: $error');
+            },
+            loading: () => const CircularProgressIndicator(),
           ),
         ),
       ],

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
@@ -177,7 +177,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1"
+    version: "1.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -216,10 +216,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -301,10 +301,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -317,10 +317,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -333,10 +333,10 @@ packages:
     dependency: transitive
     description:
       name: native_toolchain_rust
-      sha256: e53ef1025e2c190333ec61f638513c890c1becf11222e27b115b03bac369c6be
+      sha256: faa57d2258a3b0fd2a634054f54e4496c9fcbd971977e7d2b7e6916d56892857
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4+0"
   node_preamble:
     dependency: transitive
     description:
@@ -538,26 +538,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.28.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.17"
   toml:
     dependency: transitive
     description:

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1,5 +1,6 @@
 import 'dart:io' show Platform, File;
 
+import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_rust/native_toolchain_rust.dart';
 
@@ -61,15 +62,19 @@ class Env {
 }
 
 void main(List<String> args) async {
-    // we need to read an standard env file in a known-well path `$HOME/cross_build.env` to get the env vars for building, 
-  //since the hook is filtering environment variables and there is a known issue about this: https://github.com/dart-lang/native/issues/2623
-  final envFile = Env.instance;
-
-  final ndkHome = envFile.getString(_androidNDKHomeEnvVar);
-  final ndkPrebuiltRoot = '$ndkHome/toolchains/llvm/prebuilt/linux-x86_64';
-  final pkgConfigSysrootDir = '$ndkPrebuiltRoot/sysroot';
-  
   await build(args, (input, output) async {
+    // Web builds do not request code assets, and PJSIP cannot be built for web.
+    if (!input.config.buildCodeAssets) {
+      return;
+    }
+
+    // Read environment variables from `$HOME/cross_build.env` because hooks
+    // filter the process environment: https://github.com/dart-lang/native/issues/2623
+    final envFile = Env.instance;
+    final ndkHome = envFile.getString(_androidNDKHomeEnvVar);
+    final ndkPrebuiltRoot = '$ndkHome/toolchains/llvm/prebuilt/linux-x86_64';
+    final pkgConfigSysrootDir = '$ndkPrebuiltRoot/sysroot';
+
     await RustBuilder(
       assetName: 'flutter_rust_sip',
       cratePath: 'rust',
@@ -77,9 +82,6 @@ void main(List<String> args) async {
         _pkgConfigSysrootx8664EnvVar: pkgConfigSysrootDir,
         _pkgConfigSysrootAarch64EnvVar: pkgConfigSysrootDir,
       },
-    ).run(
-      input: input,
-      output: output,
-    );
+    ).run(input: input, output: output);
   });
 }

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -4,10 +4,8 @@ import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_rust/native_toolchain_rust.dart';
 
-const _pkgConfigSysrootx8664EnvVar =
-    'PKG_CONFIG_SYSROOT_DIR_x86_64_linux_android';
-const _pkgConfigSysrootAarch64EnvVar =
-    'PKG_CONFIG_SYSROOT_DIR_aarch64_linux_android';
+const _pkgConfigSysrootx8664EnvVar = 'PKG_CONFIG_SYSROOT_DIR_x86_64_linux_android';
+const _pkgConfigSysrootAarch64EnvVar = 'PKG_CONFIG_SYSROOT_DIR_aarch64_linux_android';
 const _androidNDKHomeEnvVar = 'ANDROID_NDK_HOME';
 
 class Env {
@@ -19,8 +17,7 @@ class Env {
     // read cwd .env
     _env = Platform.environment.map((key, value) => MapEntry(key, value));
     // find $HOME/frtp_build.env file
-    final home =
-        Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'];
+    final home = Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'];
     final file = File('$home/cross_build.env');
     // coverage:ignore-start
     if (file.existsSync()) {
@@ -28,9 +25,7 @@ class Env {
       for (final line in lines) {
         int index = line.indexOf("=");
         if (index != -1) {
-          _env[line.substring(0, index).trim()] = line
-              .substring(index + 1)
-              .trim();
+          _env[line.substring(0, index).trim()] = line.substring(index + 1).trim();
         }
       }
     }

--- a/lib/flutter_rust_sip.dart
+++ b/lib/flutter_rust_sip.dart
@@ -31,13 +31,11 @@ Stream<CallInfo> registerCallStream() => sipApi.registerCallStream();
 
 Stream<AccountInfo> registerAccountStream() => sipApi.registerAccountStream();
 
-Future<void> markCallAlive({required int callId}) =>
-    sipApi.markCallAlive(callId: callId);
+Future<void> markCallAlive({required int callId}) => sipApi.markCallAlive(callId: callId);
 
 Future<int> makeCall({required String phoneNumber, required String domain}) =>
     sipApi.makeCall(phoneNumber: phoneNumber, domain: domain);
 
-Future<void> hangupCall({required int callId}) =>
-    sipApi.hangupCall(callId: callId);
+Future<void> hangupCall({required int callId}) => sipApi.hangupCall(callId: callId);
 
 Future<int> destroyPjsua() => sipApi.destroyPjsua();

--- a/lib/flutter_rust_sip.dart
+++ b/lib/flutter_rust_sip.dart
@@ -1,21 +1,43 @@
 library;
 
-import 'rust/api/simple.dart' as rlib;
+import 'rust/core/dart_types.dart';
 import 'rust/core/types.dart' show OnIncommingCall;
+import 'sip_api.dart';
 
-export 'rust/frb_generated.dart' show RustLib;
 export 'rust/core/dart_types.dart';
-export 'rust/core/types.dart'
-    show OnIncommingCall;
+export 'rust/core/types.dart' show OnIncommingCall;
+export 'rust_lib.dart' show RustLib;
+export 'sip_api.dart';
+
+Future<void> initialize() => sipApi.initialize();
 
 Future<int> init({
   int localPort = 5060,
   OnIncommingCall incomingCallStrategy = OnIncommingCall.autoAnswer,
   String stunSrv = "stun:stun.l.google.com:19302",
-}) async {
-  return await rlib.initPjsua(
-    localPort: localPort,
-    incomingCallStrategy: incomingCallStrategy,
-    stunSrv: stunSrv,
-  );
-}
+}) => sipApi.initPjsua(
+  localPort: localPort,
+  incomingCallStrategy: incomingCallStrategy,
+  stunSrv: stunSrv,
+);
+
+Future<int> accountSetup({
+  required String uri,
+  required String username,
+  required String password,
+}) => sipApi.accountSetup(uri: uri, username: username, password: password);
+
+Stream<CallInfo> registerCallStream() => sipApi.registerCallStream();
+
+Stream<AccountInfo> registerAccountStream() => sipApi.registerAccountStream();
+
+Future<void> markCallAlive({required int callId}) =>
+    sipApi.markCallAlive(callId: callId);
+
+Future<int> makeCall({required String phoneNumber, required String domain}) =>
+    sipApi.makeCall(phoneNumber: phoneNumber, domain: domain);
+
+Future<void> hangupCall({required int callId}) =>
+    sipApi.hangupCall(callId: callId);
+
+Future<int> destroyPjsua() => sipApi.destroyPjsua();

--- a/lib/rust/api/simple.dart
+++ b/lib/rust/api/simple.dart
@@ -30,8 +30,7 @@ Future<int> accountSetup({
   password: password,
 );
 
-Stream<CallInfo> registerCallStream() =>
-    RustLib.instance.api.crateApiSimpleRegisterCallStream();
+Stream<CallInfo> registerCallStream() => RustLib.instance.api.crateApiSimpleRegisterCallStream();
 
 Stream<AccountInfo> registerAccountStream() =>
     RustLib.instance.api.crateApiSimpleRegisterAccountStream();
@@ -40,10 +39,7 @@ Future<void> markCallAlive({required int callId}) =>
     RustLib.instance.api.crateApiSimpleMarkCallAlive(callId: callId);
 
 Future<int> makeCall({required String phoneNumber, required String domain}) =>
-    RustLib.instance.api.crateApiSimpleMakeCall(
-      phoneNumber: phoneNumber,
-      domain: domain,
-    );
+    RustLib.instance.api.crateApiSimpleMakeCall(phoneNumber: phoneNumber, domain: domain);
 
 Future<void> hangupCall({required int callId}) =>
     RustLib.instance.api.crateApiSimpleHangupCall(callId: callId);

--- a/lib/rust/api/simple.dart
+++ b/lib/rust/api/simple.dart
@@ -8,42 +8,24 @@ import '../core/types.dart';
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-Future<int> initPjsua({
-  required int localPort,
-  required OnIncommingCall incomingCallStrategy,
-  required String stunSrv,
-}) => RustLib.instance.api.crateApiSimpleInitPjsua(
-  localPort: localPort,
-  incomingCallStrategy: incomingCallStrategy,
-  stunSrv: stunSrv,
-);
 
-Future<int> accountSetup({
-  required String uri,
-  required String username,
-  required String password,
-}) => RustLib.instance.api.crateApiSimpleAccountSetup(
-  uri: uri,
-  username: username,
-  password: password,
-);
+            
 
-Stream<CallInfo> registerCallStream() =>
-    RustLib.instance.api.crateApiSimpleRegisterCallStream();
+            Future<int>  initPjsua({required int localPort , required OnIncommingCall incomingCallStrategy , required String stunSrv , required LogLevel logLevel }) => RustLib.instance.api.crateApiSimpleInitPjsua(localPort: localPort, incomingCallStrategy: incomingCallStrategy, stunSrv: stunSrv, logLevel: logLevel);
 
-Stream<AccountInfo> registerAccountStream() =>
-    RustLib.instance.api.crateApiSimpleRegisterAccountStream();
+Future<int>  accountSetup({required String uri , required String username , required String password }) => RustLib.instance.api.crateApiSimpleAccountSetup(uri: uri, username: username, password: password);
 
-Future<void> markCallAlive({required int callId}) =>
-    RustLib.instance.api.crateApiSimpleMarkCallAlive(callId: callId);
+Stream<CallInfo>  registerCallStream() => RustLib.instance.api.crateApiSimpleRegisterCallStream();
 
-Future<int> makeCall({required String phoneNumber, required String domain}) =>
-    RustLib.instance.api.crateApiSimpleMakeCall(
-      phoneNumber: phoneNumber,
-      domain: domain,
-    );
+Stream<AccountInfo>  registerAccountStream() => RustLib.instance.api.crateApiSimpleRegisterAccountStream();
 
-Future<void> hangupCall({required int callId}) =>
-    RustLib.instance.api.crateApiSimpleHangupCall(callId: callId);
+Future<void>  markCallAlive({required int callId }) => RustLib.instance.api.crateApiSimpleMarkCallAlive(callId: callId);
 
-Future<int> destroyPjsua() => RustLib.instance.api.crateApiSimpleDestroyPjsua();
+Future<int>  makeCall({required String phoneNumber , required String domain }) => RustLib.instance.api.crateApiSimpleMakeCall(phoneNumber: phoneNumber, domain: domain);
+
+Future<void>  hangupCall({required int callId }) => RustLib.instance.api.crateApiSimpleHangupCall(callId: callId);
+
+Future<int>  destroyPjsua() => RustLib.instance.api.crateApiSimpleDestroyPjsua();
+
+            
+            

--- a/lib/rust/api/simple.dart
+++ b/lib/rust/api/simple.dart
@@ -8,24 +8,44 @@ import '../core/types.dart';
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
+Future<int> initPjsua({
+  required int localPort,
+  required OnIncommingCall incomingCallStrategy,
+  required String stunSrv,
+  required LogLevel logLevel,
+}) => RustLib.instance.api.crateApiSimpleInitPjsua(
+  localPort: localPort,
+  incomingCallStrategy: incomingCallStrategy,
+  stunSrv: stunSrv,
+  logLevel: logLevel,
+);
 
-            
+Future<int> accountSetup({
+  required String uri,
+  required String username,
+  required String password,
+}) => RustLib.instance.api.crateApiSimpleAccountSetup(
+  uri: uri,
+  username: username,
+  password: password,
+);
 
-            Future<int>  initPjsua({required int localPort , required OnIncommingCall incomingCallStrategy , required String stunSrv , required LogLevel logLevel }) => RustLib.instance.api.crateApiSimpleInitPjsua(localPort: localPort, incomingCallStrategy: incomingCallStrategy, stunSrv: stunSrv, logLevel: logLevel);
+Stream<CallInfo> registerCallStream() =>
+    RustLib.instance.api.crateApiSimpleRegisterCallStream();
 
-Future<int>  accountSetup({required String uri , required String username , required String password }) => RustLib.instance.api.crateApiSimpleAccountSetup(uri: uri, username: username, password: password);
+Stream<AccountInfo> registerAccountStream() =>
+    RustLib.instance.api.crateApiSimpleRegisterAccountStream();
 
-Stream<CallInfo>  registerCallStream() => RustLib.instance.api.crateApiSimpleRegisterCallStream();
+Future<void> markCallAlive({required int callId}) =>
+    RustLib.instance.api.crateApiSimpleMarkCallAlive(callId: callId);
 
-Stream<AccountInfo>  registerAccountStream() => RustLib.instance.api.crateApiSimpleRegisterAccountStream();
+Future<int> makeCall({required String phoneNumber, required String domain}) =>
+    RustLib.instance.api.crateApiSimpleMakeCall(
+      phoneNumber: phoneNumber,
+      domain: domain,
+    );
 
-Future<void>  markCallAlive({required int callId }) => RustLib.instance.api.crateApiSimpleMarkCallAlive(callId: callId);
+Future<void> hangupCall({required int callId}) =>
+    RustLib.instance.api.crateApiSimpleHangupCall(callId: callId);
 
-Future<int>  makeCall({required String phoneNumber , required String domain }) => RustLib.instance.api.crateApiSimpleMakeCall(phoneNumber: phoneNumber, domain: domain);
-
-Future<void>  hangupCall({required int callId }) => RustLib.instance.api.crateApiSimpleHangupCall(callId: callId);
-
-Future<int>  destroyPjsua() => RustLib.instance.api.crateApiSimpleDestroyPjsua();
-
-            
-            
+Future<int> destroyPjsua() => RustLib.instance.api.crateApiSimpleDestroyPjsua();

--- a/lib/rust/core/dart_types.dart
+++ b/lib/rust/core/dart_types.dart
@@ -31,11 +31,7 @@ class CallInfo {
   final String callUrl;
   final CallState state;
 
-  const CallInfo({
-    required this.callId,
-    required this.callUrl,
-    required this.state,
-  });
+  const CallInfo({required this.callId, required this.callUrl, required this.state});
 
   @override
   int get hashCode => callId.hashCode ^ callUrl.hashCode ^ state.hashCode;

--- a/lib/rust/core/dart_types.dart
+++ b/lib/rust/core/dart_types.dart
@@ -8,74 +8,58 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'dart_types.freezed.dart';
 
-            
+class AccountInfo {
+  final int accId;
+  final int statusCode;
 
-            
+  const AccountInfo({required this.accId, required this.statusCode});
 
-            class AccountInfo  {
-                final int accId;
-final int statusCode;
+  @override
+  int get hashCode => accId.hashCode ^ statusCode.hashCode;
 
-                const AccountInfo({required this.accId ,required this.statusCode ,});
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AccountInfo &&
+          runtimeType == other.runtimeType &&
+          accId == other.accId &&
+          statusCode == other.statusCode;
+}
 
-                
-                
+class CallInfo {
+  final int callId;
+  final String callUrl;
+  final CallState state;
 
-                
-        @override
-        int get hashCode => accId.hashCode^statusCode.hashCode;
-        
+  const CallInfo({
+    required this.callId,
+    required this.callUrl,
+    required this.state,
+  });
 
-                
-        @override
-        bool operator ==(Object other) =>
-            identical(this, other) ||
-            other is AccountInfo &&
-                runtimeType == other.runtimeType
-                && accId == other.accId&& statusCode == other.statusCode;
-        
-            }
+  @override
+  int get hashCode => callId.hashCode ^ callUrl.hashCode ^ state.hashCode;
 
-class CallInfo  {
-                final int callId;
-final String callUrl;
-final CallState state;
-
-                const CallInfo({required this.callId ,required this.callUrl ,required this.state ,});
-
-                
-                
-
-                
-        @override
-        int get hashCode => callId.hashCode^callUrl.hashCode^state.hashCode;
-        
-
-                
-        @override
-        bool operator ==(Object other) =>
-            identical(this, other) ||
-            other is CallInfo &&
-                runtimeType == other.runtimeType
-                && callId == other.callId&& callUrl == other.callUrl&& state == other.state;
-        
-            }
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CallInfo &&
+          runtimeType == other.runtimeType &&
+          callId == other.callId &&
+          callUrl == other.callUrl &&
+          state == other.state;
+}
 
 @freezed
-                sealed class CallState with _$CallState  {
-                    const CallState._();
+sealed class CallState with _$CallState {
+  const CallState._();
 
-                     const factory CallState.null_() = CallState_Null;
- const factory CallState.early() = CallState_Early;
- const factory CallState.incoming() = CallState_Incoming;
- const factory CallState.calling() = CallState_Calling;
- const factory CallState.connecting() = CallState_Connecting;
- const factory CallState.confirmed() = CallState_Confirmed;
- const factory CallState.disconnected() = CallState_Disconnected;
- const factory CallState.error(  String field0,) = CallState_Error;
-
-                    
-
-                    
-                }
-            
+  const factory CallState.null_() = CallState_Null;
+  const factory CallState.early() = CallState_Early;
+  const factory CallState.incoming() = CallState_Incoming;
+  const factory CallState.calling() = CallState_Calling;
+  const factory CallState.connecting() = CallState_Connecting;
+  const factory CallState.confirmed() = CallState_Confirmed;
+  const factory CallState.disconnected() = CallState_Disconnected;
+  const factory CallState.error(String field0) = CallState_Error;
+}

--- a/lib/rust/core/dart_types.dart
+++ b/lib/rust/core/dart_types.dart
@@ -8,58 +8,74 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'dart_types.freezed.dart';
 
-class AccountInfo {
-  final int accId;
-  final int statusCode;
+            
 
-  const AccountInfo({required this.accId, required this.statusCode});
+            
 
-  @override
-  int get hashCode => accId.hashCode ^ statusCode.hashCode;
+            class AccountInfo  {
+                final int accId;
+final int statusCode;
 
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is AccountInfo &&
-          runtimeType == other.runtimeType &&
-          accId == other.accId &&
-          statusCode == other.statusCode;
-}
+                const AccountInfo({required this.accId ,required this.statusCode ,});
 
-class CallInfo {
-  final int callId;
-  final String callUrl;
-  final CallState state;
+                
+                
 
-  const CallInfo({
-    required this.callId,
-    required this.callUrl,
-    required this.state,
-  });
+                
+        @override
+        int get hashCode => accId.hashCode^statusCode.hashCode;
+        
 
-  @override
-  int get hashCode => callId.hashCode ^ callUrl.hashCode ^ state.hashCode;
+                
+        @override
+        bool operator ==(Object other) =>
+            identical(this, other) ||
+            other is AccountInfo &&
+                runtimeType == other.runtimeType
+                && accId == other.accId&& statusCode == other.statusCode;
+        
+            }
 
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is CallInfo &&
-          runtimeType == other.runtimeType &&
-          callId == other.callId &&
-          callUrl == other.callUrl &&
-          state == other.state;
-}
+class CallInfo  {
+                final int callId;
+final String callUrl;
+final CallState state;
+
+                const CallInfo({required this.callId ,required this.callUrl ,required this.state ,});
+
+                
+                
+
+                
+        @override
+        int get hashCode => callId.hashCode^callUrl.hashCode^state.hashCode;
+        
+
+                
+        @override
+        bool operator ==(Object other) =>
+            identical(this, other) ||
+            other is CallInfo &&
+                runtimeType == other.runtimeType
+                && callId == other.callId&& callUrl == other.callUrl&& state == other.state;
+        
+            }
 
 @freezed
-sealed class CallState with _$CallState {
-  const CallState._();
+                sealed class CallState with _$CallState  {
+                    const CallState._();
 
-  const factory CallState.null_() = CallState_Null;
-  const factory CallState.early() = CallState_Early;
-  const factory CallState.incoming() = CallState_Incoming;
-  const factory CallState.calling() = CallState_Calling;
-  const factory CallState.connecting() = CallState_Connecting;
-  const factory CallState.confirmed() = CallState_Confirmed;
-  const factory CallState.disconnected() = CallState_Disconnected;
-  const factory CallState.error(String field0) = CallState_Error;
-}
+                     const factory CallState.null_() = CallState_Null;
+ const factory CallState.early() = CallState_Early;
+ const factory CallState.incoming() = CallState_Incoming;
+ const factory CallState.calling() = CallState_Calling;
+ const factory CallState.connecting() = CallState_Connecting;
+ const factory CallState.confirmed() = CallState_Confirmed;
+ const factory CallState.disconnected() = CallState_Disconnected;
+ const factory CallState.error(  String field0,) = CallState_Error;
+
+                    
+
+                    
+                }
+            

--- a/lib/rust/core/types.dart
+++ b/lib/rust/core/types.dart
@@ -8,30 +8,48 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'types.freezed.dart';
 
-enum OnIncommingCall { autoAnswer, ignore }
+            
+
+            
+
+            enum LogLevel {
+                    /// Errors only
+error,
+/// Errors and warnings
+warning,
+/// Informational (registration, call setup, etc.)
+info,
+/// Verbose debug output
+debug,
+                    ;
+                    
+                }
+
+enum OnIncommingCall {
+                    autoAnswer,
+ignore,
+                    ;
+                    
+                }
 
 @freezed
-sealed class PJSUAError with _$PJSUAError implements FrbException {
-  const PJSUAError._();
+                sealed class PJSUAError with _$PJSUAError implements FrbException {
+                    const PJSUAError._();
 
-  const factory PJSUAError.creationError(String field0) =
-      PJSUAError_CreationError;
-  const factory PJSUAError.configError(String field0) = PJSUAError_ConfigError;
-  const factory PJSUAError.initializationError(String field0) =
-      PJSUAError_InitializationError;
-  const factory PJSUAError.transportError(String field0) =
-      PJSUAError_TransportError;
-  const factory PJSUAError.dtmfError(String field0) = PJSUAError_DTMFError;
-  const factory PJSUAError.callCreationError(String field0) =
-      PJSUAError_CallCreationError;
-  const factory PJSUAError.callStatusUpdateError(String field0) =
-      PJSUAError_CallStatusUpdateError;
-  const factory PJSUAError.accountCreationError(String field0) =
-      PJSUAError_AccountCreationError;
-  const factory PJSUAError.pjsuaStartError(String field0) =
-      PJSUAError_PJSUAStartError;
-  const factory PJSUAError.pjsuaDestroyError(String field0) =
-      PJSUAError_PJSUADestroyError;
-  const factory PJSUAError.inputValueError(String field0) =
-      PJSUAError_InputValueError;
-}
+                     const factory PJSUAError.creationError(  String field0,) = PJSUAError_CreationError;
+ const factory PJSUAError.configError(  String field0,) = PJSUAError_ConfigError;
+ const factory PJSUAError.initializationError(  String field0,) = PJSUAError_InitializationError;
+ const factory PJSUAError.transportError(  String field0,) = PJSUAError_TransportError;
+ const factory PJSUAError.dtmfError(  String field0,) = PJSUAError_DTMFError;
+ const factory PJSUAError.callCreationError(  String field0,) = PJSUAError_CallCreationError;
+ const factory PJSUAError.callStatusUpdateError(  String field0,) = PJSUAError_CallStatusUpdateError;
+ const factory PJSUAError.accountCreationError(  String field0,) = PJSUAError_AccountCreationError;
+ const factory PJSUAError.pjsuaStartError(  String field0,) = PJSUAError_PJSUAStartError;
+ const factory PJSUAError.pjsuaDestroyError(  String field0,) = PJSUAError_PJSUADestroyError;
+ const factory PJSUAError.inputValueError(  String field0,) = PJSUAError_InputValueError;
+
+                    
+
+                    
+                }
+            

--- a/lib/rust/core/types.dart
+++ b/lib/rust/core/types.dart
@@ -28,24 +28,15 @@ enum OnIncommingCall { autoAnswer, ignore }
 sealed class PJSUAError with _$PJSUAError implements FrbException {
   const PJSUAError._();
 
-  const factory PJSUAError.creationError(String field0) =
-      PJSUAError_CreationError;
+  const factory PJSUAError.creationError(String field0) = PJSUAError_CreationError;
   const factory PJSUAError.configError(String field0) = PJSUAError_ConfigError;
-  const factory PJSUAError.initializationError(String field0) =
-      PJSUAError_InitializationError;
-  const factory PJSUAError.transportError(String field0) =
-      PJSUAError_TransportError;
+  const factory PJSUAError.initializationError(String field0) = PJSUAError_InitializationError;
+  const factory PJSUAError.transportError(String field0) = PJSUAError_TransportError;
   const factory PJSUAError.dtmfError(String field0) = PJSUAError_DTMFError;
-  const factory PJSUAError.callCreationError(String field0) =
-      PJSUAError_CallCreationError;
-  const factory PJSUAError.callStatusUpdateError(String field0) =
-      PJSUAError_CallStatusUpdateError;
-  const factory PJSUAError.accountCreationError(String field0) =
-      PJSUAError_AccountCreationError;
-  const factory PJSUAError.pjsuaStartError(String field0) =
-      PJSUAError_PJSUAStartError;
-  const factory PJSUAError.pjsuaDestroyError(String field0) =
-      PJSUAError_PJSUADestroyError;
-  const factory PJSUAError.inputValueError(String field0) =
-      PJSUAError_InputValueError;
+  const factory PJSUAError.callCreationError(String field0) = PJSUAError_CallCreationError;
+  const factory PJSUAError.callStatusUpdateError(String field0) = PJSUAError_CallStatusUpdateError;
+  const factory PJSUAError.accountCreationError(String field0) = PJSUAError_AccountCreationError;
+  const factory PJSUAError.pjsuaStartError(String field0) = PJSUAError_PJSUAStartError;
+  const factory PJSUAError.pjsuaDestroyError(String field0) = PJSUAError_PJSUADestroyError;
+  const factory PJSUAError.inputValueError(String field0) = PJSUAError_InputValueError;
 }

--- a/lib/rust/core/types.dart
+++ b/lib/rust/core/types.dart
@@ -8,48 +8,44 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'types.freezed.dart';
 
-            
+enum LogLevel {
+  /// Errors only
+  error,
 
-            
+  /// Errors and warnings
+  warning,
 
-            enum LogLevel {
-                    /// Errors only
-error,
-/// Errors and warnings
-warning,
-/// Informational (registration, call setup, etc.)
-info,
-/// Verbose debug output
-debug,
-                    ;
-                    
-                }
+  /// Informational (registration, call setup, etc.)
+  info,
 
-enum OnIncommingCall {
-                    autoAnswer,
-ignore,
-                    ;
-                    
-                }
+  /// Verbose debug output
+  debug,
+}
+
+enum OnIncommingCall { autoAnswer, ignore }
 
 @freezed
-                sealed class PJSUAError with _$PJSUAError implements FrbException {
-                    const PJSUAError._();
+sealed class PJSUAError with _$PJSUAError implements FrbException {
+  const PJSUAError._();
 
-                     const factory PJSUAError.creationError(  String field0,) = PJSUAError_CreationError;
- const factory PJSUAError.configError(  String field0,) = PJSUAError_ConfigError;
- const factory PJSUAError.initializationError(  String field0,) = PJSUAError_InitializationError;
- const factory PJSUAError.transportError(  String field0,) = PJSUAError_TransportError;
- const factory PJSUAError.dtmfError(  String field0,) = PJSUAError_DTMFError;
- const factory PJSUAError.callCreationError(  String field0,) = PJSUAError_CallCreationError;
- const factory PJSUAError.callStatusUpdateError(  String field0,) = PJSUAError_CallStatusUpdateError;
- const factory PJSUAError.accountCreationError(  String field0,) = PJSUAError_AccountCreationError;
- const factory PJSUAError.pjsuaStartError(  String field0,) = PJSUAError_PJSUAStartError;
- const factory PJSUAError.pjsuaDestroyError(  String field0,) = PJSUAError_PJSUADestroyError;
- const factory PJSUAError.inputValueError(  String field0,) = PJSUAError_InputValueError;
-
-                    
-
-                    
-                }
-            
+  const factory PJSUAError.creationError(String field0) =
+      PJSUAError_CreationError;
+  const factory PJSUAError.configError(String field0) = PJSUAError_ConfigError;
+  const factory PJSUAError.initializationError(String field0) =
+      PJSUAError_InitializationError;
+  const factory PJSUAError.transportError(String field0) =
+      PJSUAError_TransportError;
+  const factory PJSUAError.dtmfError(String field0) = PJSUAError_DTMFError;
+  const factory PJSUAError.callCreationError(String field0) =
+      PJSUAError_CallCreationError;
+  const factory PJSUAError.callStatusUpdateError(String field0) =
+      PJSUAError_CallStatusUpdateError;
+  const factory PJSUAError.accountCreationError(String field0) =
+      PJSUAError_AccountCreationError;
+  const factory PJSUAError.pjsuaStartError(String field0) =
+      PJSUAError_PJSUAStartError;
+  const factory PJSUAError.pjsuaDestroyError(String field0) =
+      PJSUAError_PJSUADestroyError;
+  const factory PJSUAError.inputValueError(String field0) =
+      PJSUAError_InputValueError;
+}

--- a/lib/rust/frb_generated.dart
+++ b/lib/rust/frb_generated.dart
@@ -9,8 +9,7 @@ import 'core/types.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart'
-    if (dart.library.js_interop) 'frb_generated.web.dart';
+import 'frb_generated.io.dart' if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 /// Main entrypoint of the Rust API
@@ -48,12 +47,10 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   static void dispose() => instance.disposeImpl();
 
   @override
-  ApiImplConstructor<RustLibApiImpl, RustLibWire> get apiImplConstructor =>
-      RustLibApiImpl.new;
+  ApiImplConstructor<RustLibApiImpl, RustLibWire> get apiImplConstructor => RustLibApiImpl.new;
 
   @override
-  WireConstructor<RustLibWire> get wireConstructor =>
-      RustLibWire.fromExternalLibrary;
+  WireConstructor<RustLibWire> get wireConstructor => RustLibWire.fromExternalLibrary;
 
   @override
   Future<void> executeRustInitializers() async {
@@ -70,12 +67,11 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   @override
   int get rustContentHash => -175070977;
 
-  static const kDefaultExternalLibraryLoaderConfig =
-      ExternalLibraryLoaderConfig(
-        stem: 'flutter_rust_sip',
-        ioDirectory: 'rust/target/release/',
-        webPrefix: 'pkg/',
-      );
+  static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
+    stem: 'flutter_rust_sip',
+    ioDirectory: 'rust/target/release/',
+    webPrefix: 'pkg/',
+  );
 }
 
 abstract class RustLibApi extends BaseApi {
@@ -98,10 +94,7 @@ abstract class RustLibApi extends BaseApi {
     required LogLevel logLevel,
   });
 
-  Future<int> crateApiSimpleMakeCall({
-    required String phoneNumber,
-    required String domain,
-  });
+  Future<int> crateApiSimpleMakeCall({required String phoneNumber, required String domain});
 
   Future<void> crateApiSimpleMarkCallAlive({required int callId});
 
@@ -131,12 +124,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(uri, serializer);
           sse_encode_String(username, serializer);
           sse_encode_String(password, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 1,
-            port: port_,
-          );
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_i_32,
@@ -149,10 +137,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     );
   }
 
-  TaskConstMeta get kCrateApiSimpleAccountSetupConstMeta => const TaskConstMeta(
-    debugName: "account_setup",
-    argNames: ["uri", "username", "password"],
-  );
+  TaskConstMeta get kCrateApiSimpleAccountSetupConstMeta =>
+      const TaskConstMeta(debugName: "account_setup", argNames: ["uri", "username", "password"]);
 
   @override
   Future<int> crateApiSimpleDestroyPjsua() {
@@ -160,17 +146,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 2,
-            port: port_,
-          );
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2, port: port_);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_i_8,
-          decodeErrorData: sse_decode_pjsua_error,
-        ),
+        codec: SseCodec(decodeSuccessData: sse_decode_i_8, decodeErrorData: sse_decode_pjsua_error),
         constMeta: kCrateApiSimpleDestroyPjsuaConstMeta,
         argValues: [],
         apiImpl: this,
@@ -188,12 +166,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_i_32(callId, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 3,
-            port: port_,
-          );
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 3, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -215,17 +188,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 4,
-            port: port_,
-          );
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4, port: port_);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: null,
-        ),
+        codec: SseCodec(decodeSuccessData: sse_decode_unit, decodeErrorData: null),
         constMeta: kCrateApiSimpleInitAppConstMeta,
         argValues: [],
         apiImpl: this,
@@ -251,17 +216,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_on_incomming_call(incomingCallStrategy, serializer);
           sse_encode_String(stunSrv, serializer);
           sse_encode_log_level(logLevel, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 5,
-            port: port_,
-          );
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5, port: port_);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_i_8,
-          decodeErrorData: sse_decode_pjsua_error,
-        ),
+        codec: SseCodec(decodeSuccessData: sse_decode_i_8, decodeErrorData: sse_decode_pjsua_error),
         constMeta: kCrateApiSimpleInitPjsuaConstMeta,
         argValues: [localPort, incomingCallStrategy, stunSrv, logLevel],
         apiImpl: this,
@@ -275,22 +232,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
-  Future<int> crateApiSimpleMakeCall({
-    required String phoneNumber,
-    required String domain,
-  }) {
+  Future<int> crateApiSimpleMakeCall({required String phoneNumber, required String domain}) {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(phoneNumber, serializer);
           sse_encode_String(domain, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 6,
-            port: port_,
-          );
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_i_32,
@@ -303,10 +252,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     );
   }
 
-  TaskConstMeta get kCrateApiSimpleMakeCallConstMeta => const TaskConstMeta(
-    debugName: "make_call",
-    argNames: ["phoneNumber", "domain"],
-  );
+  TaskConstMeta get kCrateApiSimpleMakeCallConstMeta =>
+      const TaskConstMeta(debugName: "make_call", argNames: ["phoneNumber", "domain"]);
 
   @override
   Future<void> crateApiSimpleMarkCallAlive({required int callId}) {
@@ -315,17 +262,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_i_32(callId, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 7,
-            port: port_,
-          );
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7, port: port_);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: null,
-        ),
+        codec: SseCodec(decodeSuccessData: sse_decode_unit, decodeErrorData: null),
         constMeta: kCrateApiSimpleMarkCallAliveConstMeta,
         argValues: [callId],
         apiImpl: this,
@@ -345,17 +284,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           callFfi: (port_) {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_StreamSink_account_info_Sse(accountSink, serializer);
-            pdeCallFfi(
-              generalizedFrbRustBinding,
-              serializer,
-              funcId: 8,
-              port: port_,
-            );
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8, port: port_);
           },
-          codec: SseCodec(
-            decodeSuccessData: sse_decode_unit,
-            decodeErrorData: null,
-          ),
+          codec: SseCodec(decodeSuccessData: sse_decode_unit, decodeErrorData: null),
           constMeta: kCrateApiSimpleRegisterAccountStreamConstMeta,
           argValues: [accountSink],
           apiImpl: this,
@@ -366,10 +297,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   TaskConstMeta get kCrateApiSimpleRegisterAccountStreamConstMeta =>
-      const TaskConstMeta(
-        debugName: "register_account_stream",
-        argNames: ["accountSink"],
-      );
+      const TaskConstMeta(debugName: "register_account_stream", argNames: ["accountSink"]);
 
   @override
   Stream<CallInfo> crateApiSimpleRegisterCallStream() {
@@ -380,17 +308,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           callFfi: (port_) {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_StreamSink_call_info_Sse(callSink, serializer);
-            pdeCallFfi(
-              generalizedFrbRustBinding,
-              serializer,
-              funcId: 9,
-              port: port_,
-            );
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9, port: port_);
           },
-          codec: SseCodec(
-            decodeSuccessData: sse_decode_unit,
-            decodeErrorData: null,
-          ),
+          codec: SseCodec(decodeSuccessData: sse_decode_unit, decodeErrorData: null),
           constMeta: kCrateApiSimpleRegisterCallStreamConstMeta,
           argValues: [callSink],
           apiImpl: this,
@@ -401,10 +321,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   TaskConstMeta get kCrateApiSimpleRegisterCallStreamConstMeta =>
-      const TaskConstMeta(
-        debugName: "register_call_stream",
-        argNames: ["callSink"],
-      );
+      const TaskConstMeta(debugName: "register_call_stream", argNames: ["callSink"]);
 
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw) {
@@ -413,9 +330,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(
-    dynamic raw,
-  ) {
+  RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     throw UnimplementedError();
   }
@@ -436,20 +351,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   AccountInfo dco_decode_account_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-    return AccountInfo(
-      accId: dco_decode_i_32(arr[0]),
-      statusCode: dco_decode_i_32(arr[1]),
-    );
+    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return AccountInfo(accId: dco_decode_i_32(arr[0]), statusCode: dco_decode_i_32(arr[1]));
   }
 
   @protected
   CallInfo dco_decode_call_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3)
-      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return CallInfo(
       callId: dco_decode_i_32(arr[0]),
       callUrl: dco_decode_String(arr[1]),
@@ -569,17 +479,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(
-    SseDeserializer deserializer,
-  ) {
+  RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     throw UnimplementedError('Unreachable ()');
   }
 
   @protected
-  RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(
-    SseDeserializer deserializer,
-  ) {
+  RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     throw UnimplementedError('Unreachable ()');
   }
@@ -737,10 +643,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_AnyhowException(
-    AnyhowException self,
-    SseSerializer serializer,
-  ) {
+  void sse_encode_AnyhowException(AnyhowException self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.message, serializer);
   }
@@ -837,10 +740,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_list_prim_u_8_strict(
-    Uint8List self,
-    SseSerializer serializer,
-  ) {
+  void sse_encode_list_prim_u_8_strict(Uint8List self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.length, serializer);
     serializer.buffer.putUint8List(self);
@@ -853,10 +753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_on_incomming_call(
-    OnIncommingCall self,
-    SseSerializer serializer,
-  ) {
+  void sse_encode_on_incomming_call(OnIncommingCall self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.index, serializer);
   }

--- a/lib/rust/frb_generated.dart
+++ b/lib/rust/frb_generated.dart
@@ -9,579 +9,918 @@ import 'core/types.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart' if (dart.library.js_interop) 'frb_generated.web.dart';
+import 'frb_generated.io.dart'
+    if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
+/// Main entrypoint of the Rust API
+class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
+  @internal
+  static final instance = RustLib._();
 
-                /// Main entrypoint of the Rust API
-                class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
-                  @internal
-                  static final instance = RustLib._();
+  RustLib._();
 
-                  RustLib._();
+  /// Initialize flutter_rust_bridge
+  static Future<void> init({
+    RustLibApi? api,
+    BaseHandler? handler,
+    ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
+  }) async {
+    await instance.initImpl(
+      api: api,
+      handler: handler,
+      externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
+    );
+  }
 
-                  /// Initialize flutter_rust_bridge
-                  static Future<void> init({
-                    RustLibApi? api,
-                    BaseHandler? handler,
-                    ExternalLibrary? externalLibrary,
-                    bool forceSameCodegenVersion = true,
-                  }) async {
-                    await instance.initImpl(
-                      api: api,
-                      handler: handler,
-                      externalLibrary: externalLibrary,
-                      forceSameCodegenVersion: forceSameCodegenVersion,
-                    );
-                  }
+  /// Initialize flutter_rust_bridge in mock mode.
+  /// No libraries for FFI are loaded.
+  static void initMock({required RustLibApi api}) {
+    instance.initMockImpl(api: api);
+  }
 
-                  /// Initialize flutter_rust_bridge in mock mode.
-                  /// No libraries for FFI are loaded.
-                  static void initMock({
-                    required RustLibApi api,
-                  }) {
-                    instance.initMockImpl(
-                      api: api,
-                    );
-                  }
+  /// Dispose flutter_rust_bridge
+  ///
+  /// The call to this function is optional, since flutter_rust_bridge (and everything else)
+  /// is automatically disposed when the app stops.
+  static void dispose() => instance.disposeImpl();
 
-                  /// Dispose flutter_rust_bridge
-                  ///
-                  /// The call to this function is optional, since flutter_rust_bridge (and everything else)
-                  /// is automatically disposed when the app stops.
-                  static void dispose() => instance.disposeImpl();
+  @override
+  ApiImplConstructor<RustLibApiImpl, RustLibWire> get apiImplConstructor =>
+      RustLibApiImpl.new;
 
-                  @override
-                  ApiImplConstructor<RustLibApiImpl, RustLibWire> get apiImplConstructor => RustLibApiImpl.new;
+  @override
+  WireConstructor<RustLibWire> get wireConstructor =>
+      RustLibWire.fromExternalLibrary;
 
-                  @override
-                  WireConstructor<RustLibWire> get wireConstructor => RustLibWire.fromExternalLibrary;
+  @override
+  Future<void> executeRustInitializers() async {
+    await api.crateApiSimpleInitApp();
+  }
 
-                  @override
-                  Future<void> executeRustInitializers() async {
-                    await api.crateApiSimpleInitApp();
+  @override
+  ExternalLibraryLoaderConfig get defaultExternalLibraryLoaderConfig =>
+      kDefaultExternalLibraryLoaderConfig;
 
-                  }
+  @override
+  String get codegenVersion => '2.11.1';
 
-                  @override
-                  ExternalLibraryLoaderConfig get defaultExternalLibraryLoaderConfig => kDefaultExternalLibraryLoaderConfig;
+  @override
+  int get rustContentHash => -175070977;
 
-                  @override
-                  String get codegenVersion => '2.11.1';
+  static const kDefaultExternalLibraryLoaderConfig =
+      ExternalLibraryLoaderConfig(
+        stem: 'flutter_rust_sip',
+        ioDirectory: 'rust/target/release/',
+        webPrefix: 'pkg/',
+      );
+}
 
-                  @override
-                  int get rustContentHash => -175070977;
+abstract class RustLibApi extends BaseApi {
+  Future<int> crateApiSimpleAccountSetup({
+    required String uri,
+    required String username,
+    required String password,
+  });
 
-                  static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
-                    stem: 'flutter_rust_sip',
-                    ioDirectory: 'rust/target/release/',
-                    webPrefix: 'pkg/',
-                  );
-                }
-                
+  Future<int> crateApiSimpleDestroyPjsua();
 
-                abstract class RustLibApi extends BaseApi {
-                  Future<int> crateApiSimpleAccountSetup({required String uri , required String username , required String password });
+  Future<void> crateApiSimpleHangupCall({required int callId});
 
-Future<int> crateApiSimpleDestroyPjsua();
+  Future<void> crateApiSimpleInitApp();
 
-Future<void> crateApiSimpleHangupCall({required int callId });
+  Future<int> crateApiSimpleInitPjsua({
+    required int localPort,
+    required OnIncommingCall incomingCallStrategy,
+    required String stunSrv,
+    required LogLevel logLevel,
+  });
 
-Future<void> crateApiSimpleInitApp();
+  Future<int> crateApiSimpleMakeCall({
+    required String phoneNumber,
+    required String domain,
+  });
 
-Future<int> crateApiSimpleInitPjsua({required int localPort , required OnIncommingCall incomingCallStrategy , required String stunSrv , required LogLevel logLevel });
+  Future<void> crateApiSimpleMarkCallAlive({required int callId});
 
-Future<int> crateApiSimpleMakeCall({required String phoneNumber , required String domain });
+  Stream<AccountInfo> crateApiSimpleRegisterAccountStream();
 
-Future<void> crateApiSimpleMarkCallAlive({required int callId });
+  Stream<CallInfo> crateApiSimpleRegisterCallStream();
+}
 
-Stream<AccountInfo> crateApiSimpleRegisterAccountStream();
+class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
+  RustLibApiImpl({
+    required super.handler,
+    required super.wire,
+    required super.generalizedFrbRustBinding,
+    required super.portManager,
+  });
 
-Stream<CallInfo> crateApiSimpleRegisterCallStream();
-
-
-                }
-                
-
-                class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
-                  RustLibApiImpl({
-                    required super.handler,
-                    required super.wire,
-                    required super.generalizedFrbRustBinding,
-                    required super.portManager,
-                  });
-
-                  @override Future<int> crateApiSimpleAccountSetup({required String uri , required String username , required String password })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_String(uri, serializer);
-sse_encode_String(username, serializer);
-sse_encode_String(password, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
+  @override
+  Future<int> crateApiSimpleAccountSetup({
+    required String uri,
+    required String username,
+    required String password,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(uri, serializer);
+          sse_encode_String(username, serializer);
+          sse_encode_String(password, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 1,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
           decodeSuccessData: sse_decode_i_32,
           decodeErrorData: sse_decode_pjsua_error,
-        )
-        ,
-            constMeta: kCrateApiSimpleAccountSetupConstMeta,
-            argValues: [uri, username, password],
-            apiImpl: this,
-        )); }
+        ),
+        constMeta: kCrateApiSimpleAccountSetupConstMeta,
+        argValues: [uri, username, password],
+        apiImpl: this,
+      ),
+    );
+  }
 
+  TaskConstMeta get kCrateApiSimpleAccountSetupConstMeta => const TaskConstMeta(
+    debugName: "account_setup",
+    argNames: ["uri", "username", "password"],
+  );
 
-        TaskConstMeta get kCrateApiSimpleAccountSetupConstMeta => const TaskConstMeta(
-            debugName: "account_setup",
-            argNames: ["uri", "username", "password"],
-        );
-        
-
-@override Future<int> crateApiSimpleDestroyPjsua()  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
+  @override
+  Future<int> crateApiSimpleDestroyPjsua() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 2,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
           decodeSuccessData: sse_decode_i_8,
           decodeErrorData: sse_decode_pjsua_error,
-        )
-        ,
-            constMeta: kCrateApiSimpleDestroyPjsuaConstMeta,
-            argValues: [],
-            apiImpl: this,
-        )); }
+        ),
+        constMeta: kCrateApiSimpleDestroyPjsuaConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
 
+  TaskConstMeta get kCrateApiSimpleDestroyPjsuaConstMeta =>
+      const TaskConstMeta(debugName: "destroy_pjsua", argNames: []);
 
-        TaskConstMeta get kCrateApiSimpleDestroyPjsuaConstMeta => const TaskConstMeta(
-            debugName: "destroy_pjsua",
-            argNames: [],
-        );
-        
-
-@override Future<void> crateApiSimpleHangupCall({required int callId })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_i_32(callId, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 3, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
+  @override
+  Future<void> crateApiSimpleHangupCall({required int callId}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_i_32(callId, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 3,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
           decodeErrorData: sse_decode_pjsua_error,
-        )
-        ,
-            constMeta: kCrateApiSimpleHangupCallConstMeta,
-            argValues: [callId],
-            apiImpl: this,
-        )); }
+        ),
+        constMeta: kCrateApiSimpleHangupCallConstMeta,
+        argValues: [callId],
+        apiImpl: this,
+      ),
+    );
+  }
 
+  TaskConstMeta get kCrateApiSimpleHangupCallConstMeta =>
+      const TaskConstMeta(debugName: "hangup_call", argNames: ["callId"]);
 
-        TaskConstMeta get kCrateApiSimpleHangupCallConstMeta => const TaskConstMeta(
-            debugName: "hangup_call",
-            argNames: ["callId"],
-        );
-        
-
-@override Future<void> crateApiSimpleInitApp()  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
+  @override
+  Future<void> crateApiSimpleInitApp() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 4,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
           decodeErrorData: null,
-        )
-        ,
-            constMeta: kCrateApiSimpleInitAppConstMeta,
-            argValues: [],
-            apiImpl: this,
-        )); }
+        ),
+        constMeta: kCrateApiSimpleInitAppConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
 
+  TaskConstMeta get kCrateApiSimpleInitAppConstMeta =>
+      const TaskConstMeta(debugName: "init_app", argNames: []);
 
-        TaskConstMeta get kCrateApiSimpleInitAppConstMeta => const TaskConstMeta(
-            debugName: "init_app",
-            argNames: [],
-        );
-        
-
-@override Future<int> crateApiSimpleInitPjsua({required int localPort , required OnIncommingCall incomingCallStrategy , required String stunSrv , required LogLevel logLevel })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_u_32(localPort, serializer);
-sse_encode_on_incomming_call(incomingCallStrategy, serializer);
-sse_encode_String(stunSrv, serializer);
-sse_encode_log_level(logLevel, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
+  @override
+  Future<int> crateApiSimpleInitPjsua({
+    required int localPort,
+    required OnIncommingCall incomingCallStrategy,
+    required String stunSrv,
+    required LogLevel logLevel,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_u_32(localPort, serializer);
+          sse_encode_on_incomming_call(incomingCallStrategy, serializer);
+          sse_encode_String(stunSrv, serializer);
+          sse_encode_log_level(logLevel, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 5,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
           decodeSuccessData: sse_decode_i_8,
           decodeErrorData: sse_decode_pjsua_error,
-        )
-        ,
-            constMeta: kCrateApiSimpleInitPjsuaConstMeta,
-            argValues: [localPort, incomingCallStrategy, stunSrv, logLevel],
-            apiImpl: this,
-        )); }
+        ),
+        constMeta: kCrateApiSimpleInitPjsuaConstMeta,
+        argValues: [localPort, incomingCallStrategy, stunSrv, logLevel],
+        apiImpl: this,
+      ),
+    );
+  }
 
+  TaskConstMeta get kCrateApiSimpleInitPjsuaConstMeta => const TaskConstMeta(
+    debugName: "init_pjsua",
+    argNames: ["localPort", "incomingCallStrategy", "stunSrv", "logLevel"],
+  );
 
-        TaskConstMeta get kCrateApiSimpleInitPjsuaConstMeta => const TaskConstMeta(
-            debugName: "init_pjsua",
-            argNames: ["localPort", "incomingCallStrategy", "stunSrv", "logLevel"],
-        );
-        
-
-@override Future<int> crateApiSimpleMakeCall({required String phoneNumber , required String domain })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_String(phoneNumber, serializer);
-sse_encode_String(domain, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
+  @override
+  Future<int> crateApiSimpleMakeCall({
+    required String phoneNumber,
+    required String domain,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(phoneNumber, serializer);
+          sse_encode_String(domain, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 6,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
           decodeSuccessData: sse_decode_i_32,
           decodeErrorData: sse_decode_pjsua_error,
-        )
-        ,
-            constMeta: kCrateApiSimpleMakeCallConstMeta,
-            argValues: [phoneNumber, domain],
-            apiImpl: this,
-        )); }
+        ),
+        constMeta: kCrateApiSimpleMakeCallConstMeta,
+        argValues: [phoneNumber, domain],
+        apiImpl: this,
+      ),
+    );
+  }
 
+  TaskConstMeta get kCrateApiSimpleMakeCallConstMeta => const TaskConstMeta(
+    debugName: "make_call",
+    argNames: ["phoneNumber", "domain"],
+  );
 
-        TaskConstMeta get kCrateApiSimpleMakeCallConstMeta => const TaskConstMeta(
-            debugName: "make_call",
-            argNames: ["phoneNumber", "domain"],
-        );
-        
-
-@override Future<void> crateApiSimpleMarkCallAlive({required int callId })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_i_32(callId, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
+  @override
+  Future<void> crateApiSimpleMarkCallAlive({required int callId}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_i_32(callId, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 7,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
           decodeErrorData: null,
-        )
-        ,
-            constMeta: kCrateApiSimpleMarkCallAliveConstMeta,
-            argValues: [callId],
-            apiImpl: this,
-        )); }
+        ),
+        constMeta: kCrateApiSimpleMarkCallAliveConstMeta,
+        argValues: [callId],
+        apiImpl: this,
+      ),
+    );
+  }
 
+  TaskConstMeta get kCrateApiSimpleMarkCallAliveConstMeta =>
+      const TaskConstMeta(debugName: "mark_call_alive", argNames: ["callId"]);
 
-        TaskConstMeta get kCrateApiSimpleMarkCallAliveConstMeta => const TaskConstMeta(
-            debugName: "mark_call_alive",
-            argNames: ["callId"],
-        );
-        
+  @override
+  Stream<AccountInfo> crateApiSimpleRegisterAccountStream() {
+    final accountSink = RustStreamSink<AccountInfo>();
+    unawaited(
+      handler.executeNormal(
+        NormalTask(
+          callFfi: (port_) {
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            sse_encode_StreamSink_account_info_Sse(accountSink, serializer);
+            pdeCallFfi(
+              generalizedFrbRustBinding,
+              serializer,
+              funcId: 8,
+              port: port_,
+            );
+          },
+          codec: SseCodec(
+            decodeSuccessData: sse_decode_unit,
+            decodeErrorData: null,
+          ),
+          constMeta: kCrateApiSimpleRegisterAccountStreamConstMeta,
+          argValues: [accountSink],
+          apiImpl: this,
+        ),
+      ),
+    );
+    return accountSink.stream;
+  }
 
-@override Stream<AccountInfo> crateApiSimpleRegisterAccountStream()  { 
-            final accountSink = RustStreamSink<AccountInfo>();
-            unawaited(handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_StreamSink_account_info_Sse(accountSink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: null,
-        )
-        ,
-            constMeta: kCrateApiSimpleRegisterAccountStreamConstMeta,
-            argValues: [accountSink],
-            apiImpl: this,
-        )));
-            return accountSink.stream;
-             }
+  TaskConstMeta get kCrateApiSimpleRegisterAccountStreamConstMeta =>
+      const TaskConstMeta(
+        debugName: "register_account_stream",
+        argNames: ["accountSink"],
+      );
 
+  @override
+  Stream<CallInfo> crateApiSimpleRegisterCallStream() {
+    final callSink = RustStreamSink<CallInfo>();
+    unawaited(
+      handler.executeNormal(
+        NormalTask(
+          callFfi: (port_) {
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            sse_encode_StreamSink_call_info_Sse(callSink, serializer);
+            pdeCallFfi(
+              generalizedFrbRustBinding,
+              serializer,
+              funcId: 9,
+              port: port_,
+            );
+          },
+          codec: SseCodec(
+            decodeSuccessData: sse_decode_unit,
+            decodeErrorData: null,
+          ),
+          constMeta: kCrateApiSimpleRegisterCallStreamConstMeta,
+          argValues: [callSink],
+          apiImpl: this,
+        ),
+      ),
+    );
+    return callSink.stream;
+  }
 
-        TaskConstMeta get kCrateApiSimpleRegisterAccountStreamConstMeta => const TaskConstMeta(
-            debugName: "register_account_stream",
-            argNames: ["accountSink"],
-        );
-        
+  TaskConstMeta get kCrateApiSimpleRegisterCallStreamConstMeta =>
+      const TaskConstMeta(
+        debugName: "register_call_stream",
+        argNames: ["callSink"],
+      );
 
-@override Stream<CallInfo> crateApiSimpleRegisterCallStream()  { 
-            final callSink = RustStreamSink<CallInfo>();
-            unawaited(handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_StreamSink_call_info_Sse(callSink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: null,
-        )
-        ,
-            constMeta: kCrateApiSimpleRegisterCallStreamConstMeta,
-            argValues: [callSink],
-            apiImpl: this,
-        )));
-            return callSink.stream;
-             }
+  @protected
+  AnyhowException dco_decode_AnyhowException(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return AnyhowException(raw as String);
+  }
 
+  @protected
+  RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    throw UnimplementedError();
+  }
 
-        TaskConstMeta get kCrateApiSimpleRegisterCallStreamConstMeta => const TaskConstMeta(
-            debugName: "register_call_stream",
-            argNames: ["callSink"],
-        );
-        
+  @protected
+  RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    throw UnimplementedError();
+  }
 
+  @protected
+  String dco_decode_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as String;
+  }
 
+  @protected
+  AccountInfo dco_decode_account_info(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return AccountInfo(
+      accId: dco_decode_i_32(arr[0]),
+      statusCode: dco_decode_i_32(arr[1]),
+    );
+  }
 
-                  @protected AnyhowException dco_decode_AnyhowException(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return AnyhowException(raw as String); }
+  @protected
+  CallInfo dco_decode_call_info(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return CallInfo(
+      callId: dco_decode_i_32(arr[0]),
+      callUrl: dco_decode_String(arr[1]),
+      state: dco_decode_call_state(arr[2]),
+    );
+  }
 
-@protected RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-throw UnimplementedError(); }
+  @protected
+  CallState dco_decode_call_state(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return CallState_Null();
+      case 1:
+        return CallState_Early();
+      case 2:
+        return CallState_Incoming();
+      case 3:
+        return CallState_Calling();
+      case 4:
+        return CallState_Connecting();
+      case 5:
+        return CallState_Confirmed();
+      case 6:
+        return CallState_Disconnected();
+      case 7:
+        return CallState_Error(dco_decode_String(raw[1]));
+      default:
+        throw Exception("unreachable");
+    }
+  }
 
-@protected RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-throw UnimplementedError(); }
+  @protected
+  int dco_decode_i_32(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as int;
+  }
 
-@protected String dco_decode_String(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as String; }
+  @protected
+  int dco_decode_i_8(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as int;
+  }
 
-@protected AccountInfo dco_decode_account_info(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-                return AccountInfo(accId: dco_decode_i_32(arr[0]),
-statusCode: dco_decode_i_32(arr[1]),); }
+  @protected
+  Uint8List dco_decode_list_prim_u_8_strict(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as Uint8List;
+  }
 
-@protected CallInfo dco_decode_call_info(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
-                return CallInfo(callId: dco_decode_i_32(arr[0]),
-callUrl: dco_decode_String(arr[1]),
-state: dco_decode_call_state(arr[2]),); }
+  @protected
+  LogLevel dco_decode_log_level(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return LogLevel.values[raw as int];
+  }
 
-@protected CallState dco_decode_call_state(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-switch (raw[0]) {
-                case 0: return CallState_Null();
-case 1: return CallState_Early();
-case 2: return CallState_Incoming();
-case 3: return CallState_Calling();
-case 4: return CallState_Connecting();
-case 5: return CallState_Confirmed();
-case 6: return CallState_Disconnected();
-case 7: return CallState_Error(dco_decode_String(raw[1]),);
-                default: throw Exception("unreachable");
-            } }
+  @protected
+  OnIncommingCall dco_decode_on_incomming_call(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return OnIncommingCall.values[raw as int];
+  }
 
-@protected int dco_decode_i_32(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as int; }
+  @protected
+  PJSUAError dco_decode_pjsua_error(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return PJSUAError_CreationError(dco_decode_String(raw[1]));
+      case 1:
+        return PJSUAError_ConfigError(dco_decode_String(raw[1]));
+      case 2:
+        return PJSUAError_InitializationError(dco_decode_String(raw[1]));
+      case 3:
+        return PJSUAError_TransportError(dco_decode_String(raw[1]));
+      case 4:
+        return PJSUAError_DTMFError(dco_decode_String(raw[1]));
+      case 5:
+        return PJSUAError_CallCreationError(dco_decode_String(raw[1]));
+      case 6:
+        return PJSUAError_CallStatusUpdateError(dco_decode_String(raw[1]));
+      case 7:
+        return PJSUAError_AccountCreationError(dco_decode_String(raw[1]));
+      case 8:
+        return PJSUAError_PJSUAStartError(dco_decode_String(raw[1]));
+      case 9:
+        return PJSUAError_PJSUADestroyError(dco_decode_String(raw[1]));
+      case 10:
+        return PJSUAError_InputValueError(dco_decode_String(raw[1]));
+      default:
+        throw Exception("unreachable");
+    }
+  }
 
-@protected int dco_decode_i_8(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as int; }
+  @protected
+  int dco_decode_u_32(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as int;
+  }
 
-@protected Uint8List dco_decode_list_prim_u_8_strict(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as Uint8List; }
+  @protected
+  int dco_decode_u_8(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as int;
+  }
 
-@protected LogLevel dco_decode_log_level(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return LogLevel.values[raw as int]; }
+  @protected
+  void dco_decode_unit(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return;
+  }
 
-@protected OnIncommingCall dco_decode_on_incomming_call(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return OnIncommingCall.values[raw as int]; }
+  @protected
+  AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_String(deserializer);
+    return AnyhowException(inner);
+  }
 
-@protected PJSUAError dco_decode_pjsua_error(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-switch (raw[0]) {
-                case 0: return PJSUAError_CreationError(dco_decode_String(raw[1]),);
-case 1: return PJSUAError_ConfigError(dco_decode_String(raw[1]),);
-case 2: return PJSUAError_InitializationError(dco_decode_String(raw[1]),);
-case 3: return PJSUAError_TransportError(dco_decode_String(raw[1]),);
-case 4: return PJSUAError_DTMFError(dco_decode_String(raw[1]),);
-case 5: return PJSUAError_CallCreationError(dco_decode_String(raw[1]),);
-case 6: return PJSUAError_CallStatusUpdateError(dco_decode_String(raw[1]),);
-case 7: return PJSUAError_AccountCreationError(dco_decode_String(raw[1]),);
-case 8: return PJSUAError_PJSUAStartError(dco_decode_String(raw[1]),);
-case 9: return PJSUAError_PJSUADestroyError(dco_decode_String(raw[1]),);
-case 10: return PJSUAError_InputValueError(dco_decode_String(raw[1]),);
-                default: throw Exception("unreachable");
-            } }
+  @protected
+  RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    throw UnimplementedError('Unreachable ()');
+  }
 
-@protected int dco_decode_u_32(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as int; }
+  @protected
+  RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    throw UnimplementedError('Unreachable ()');
+  }
 
-@protected int dco_decode_u_8(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as int; }
+  @protected
+  String sse_decode_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_list_prim_u_8_strict(deserializer);
+    return utf8.decoder.convert(inner);
+  }
 
-@protected void dco_decode_unit(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return; }
+  @protected
+  AccountInfo sse_decode_account_info(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_accId = sse_decode_i_32(deserializer);
+    var var_statusCode = sse_decode_i_32(deserializer);
+    return AccountInfo(accId: var_accId, statusCode: var_statusCode);
+  }
 
-@protected AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var inner = sse_decode_String(deserializer);
-        return AnyhowException(inner); }
+  @protected
+  CallInfo sse_decode_call_info(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_callId = sse_decode_i_32(deserializer);
+    var var_callUrl = sse_decode_String(deserializer);
+    var var_state = sse_decode_call_state(deserializer);
+    return CallInfo(callId: var_callId, callUrl: var_callUrl, state: var_state);
+  }
 
-@protected RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-throw UnimplementedError('Unreachable ()'); }
+  @protected
+  CallState sse_decode_call_state(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
 
-@protected RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-throw UnimplementedError('Unreachable ()'); }
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        return CallState_Null();
+      case 1:
+        return CallState_Early();
+      case 2:
+        return CallState_Incoming();
+      case 3:
+        return CallState_Calling();
+      case 4:
+        return CallState_Connecting();
+      case 5:
+        return CallState_Confirmed();
+      case 6:
+        return CallState_Disconnected();
+      case 7:
+        var var_field0 = sse_decode_String(deserializer);
+        return CallState_Error(var_field0);
+      default:
+        throw UnimplementedError('');
+    }
+  }
 
-@protected String sse_decode_String(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var inner = sse_decode_list_prim_u_8_strict(deserializer);
-        return utf8.decoder.convert(inner); }
+  @protected
+  int sse_decode_i_32(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getInt32();
+  }
 
-@protected AccountInfo sse_decode_account_info(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_accId = sse_decode_i_32(deserializer);
-var var_statusCode = sse_decode_i_32(deserializer);
-return AccountInfo(accId: var_accId, statusCode: var_statusCode); }
+  @protected
+  int sse_decode_i_8(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getInt8();
+  }
 
-@protected CallInfo sse_decode_call_info(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_callId = sse_decode_i_32(deserializer);
-var var_callUrl = sse_decode_String(deserializer);
-var var_state = sse_decode_call_state(deserializer);
-return CallInfo(callId: var_callId, callUrl: var_callUrl, state: var_state); }
+  @protected
+  Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var len_ = sse_decode_i_32(deserializer);
+    return deserializer.buffer.getUint8List(len_);
+  }
 
-@protected CallState sse_decode_call_state(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+  @protected
+  LogLevel sse_decode_log_level(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_32(deserializer);
+    return LogLevel.values[inner];
+  }
 
-            var tag_ = sse_decode_i_32(deserializer);
-            switch (tag_) { case 0: return CallState_Null();case 1: return CallState_Early();case 2: return CallState_Incoming();case 3: return CallState_Calling();case 4: return CallState_Connecting();case 5: return CallState_Confirmed();case 6: return CallState_Disconnected();case 7: var var_field0 = sse_decode_String(deserializer);
-return CallState_Error(var_field0); default: throw UnimplementedError(''); }
-             }
+  @protected
+  OnIncommingCall sse_decode_on_incomming_call(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_32(deserializer);
+    return OnIncommingCall.values[inner];
+  }
 
-@protected int sse_decode_i_32(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return deserializer.buffer.getInt32(); }
+  @protected
+  PJSUAError sse_decode_pjsua_error(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
 
-@protected int sse_decode_i_8(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return deserializer.buffer.getInt8(); }
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        var var_field0 = sse_decode_String(deserializer);
+        return PJSUAError_CreationError(var_field0);
+      case 1:
+        var var_field0 = sse_decode_String(deserializer);
+        return PJSUAError_ConfigError(var_field0);
+      case 2:
+        var var_field0 = sse_decode_String(deserializer);
+        return PJSUAError_InitializationError(var_field0);
+      case 3:
+        var var_field0 = sse_decode_String(deserializer);
+        return PJSUAError_TransportError(var_field0);
+      case 4:
+        var var_field0 = sse_decode_String(deserializer);
+        return PJSUAError_DTMFError(var_field0);
+      case 5:
+        var var_field0 = sse_decode_String(deserializer);
+        return PJSUAError_CallCreationError(var_field0);
+      case 6:
+        var var_field0 = sse_decode_String(deserializer);
+        return PJSUAError_CallStatusUpdateError(var_field0);
+      case 7:
+        var var_field0 = sse_decode_String(deserializer);
+        return PJSUAError_AccountCreationError(var_field0);
+      case 8:
+        var var_field0 = sse_decode_String(deserializer);
+        return PJSUAError_PJSUAStartError(var_field0);
+      case 9:
+        var var_field0 = sse_decode_String(deserializer);
+        return PJSUAError_PJSUADestroyError(var_field0);
+      case 10:
+        var var_field0 = sse_decode_String(deserializer);
+        return PJSUAError_InputValueError(var_field0);
+      default:
+        throw UnimplementedError('');
+    }
+  }
 
-@protected Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var len_ = sse_decode_i_32(deserializer);
-                return deserializer.buffer.getUint8List(len_); }
+  @protected
+  int sse_decode_u_32(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getUint32();
+  }
 
-@protected LogLevel sse_decode_log_level(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var inner = sse_decode_i_32(deserializer);
-        return LogLevel.values[inner]; }
+  @protected
+  int sse_decode_u_8(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getUint8();
+  }
 
-@protected OnIncommingCall sse_decode_on_incomming_call(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var inner = sse_decode_i_32(deserializer);
-        return OnIncommingCall.values[inner]; }
+  @protected
+  void sse_decode_unit(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+  }
 
-@protected PJSUAError sse_decode_pjsua_error(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+  @protected
+  bool sse_decode_bool(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getUint8() != 0;
+  }
 
-            var tag_ = sse_decode_i_32(deserializer);
-            switch (tag_) { case 0: var var_field0 = sse_decode_String(deserializer);
-return PJSUAError_CreationError(var_field0);case 1: var var_field0 = sse_decode_String(deserializer);
-return PJSUAError_ConfigError(var_field0);case 2: var var_field0 = sse_decode_String(deserializer);
-return PJSUAError_InitializationError(var_field0);case 3: var var_field0 = sse_decode_String(deserializer);
-return PJSUAError_TransportError(var_field0);case 4: var var_field0 = sse_decode_String(deserializer);
-return PJSUAError_DTMFError(var_field0);case 5: var var_field0 = sse_decode_String(deserializer);
-return PJSUAError_CallCreationError(var_field0);case 6: var var_field0 = sse_decode_String(deserializer);
-return PJSUAError_CallStatusUpdateError(var_field0);case 7: var var_field0 = sse_decode_String(deserializer);
-return PJSUAError_AccountCreationError(var_field0);case 8: var var_field0 = sse_decode_String(deserializer);
-return PJSUAError_PJSUAStartError(var_field0);case 9: var var_field0 = sse_decode_String(deserializer);
-return PJSUAError_PJSUADestroyError(var_field0);case 10: var var_field0 = sse_decode_String(deserializer);
-return PJSUAError_InputValueError(var_field0); default: throw UnimplementedError(''); }
-             }
+  @protected
+  void sse_encode_AnyhowException(
+    AnyhowException self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.message, serializer);
+  }
 
-@protected int sse_decode_u_32(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return deserializer.buffer.getUint32(); }
+  @protected
+  void sse_encode_StreamSink_account_info_Sse(
+    RustStreamSink<AccountInfo> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(
+      self.setupAndSerialize(
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_account_info,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+      ),
+      serializer,
+    );
+  }
 
-@protected int sse_decode_u_8(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return deserializer.buffer.getUint8(); }
+  @protected
+  void sse_encode_StreamSink_call_info_Sse(
+    RustStreamSink<CallInfo> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(
+      self.setupAndSerialize(
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_call_info,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+      ),
+      serializer,
+    );
+  }
 
-@protected void sse_decode_unit(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
- }
+  @protected
+  void sse_encode_String(String self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer);
+  }
 
-@protected bool sse_decode_bool(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return deserializer.buffer.getUint8() != 0; }
+  @protected
+  void sse_encode_account_info(AccountInfo self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.accId, serializer);
+    sse_encode_i_32(self.statusCode, serializer);
+  }
 
-@protected void sse_encode_AnyhowException(AnyhowException self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_String(self.message, serializer); }
+  @protected
+  void sse_encode_call_info(CallInfo self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.callId, serializer);
+    sse_encode_String(self.callUrl, serializer);
+    sse_encode_call_state(self.state, serializer);
+  }
 
-@protected void sse_encode_StreamSink_account_info_Sse(RustStreamSink<AccountInfo> self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_String(self.setupAndSerialize(codec: SseCodec(
-            decodeSuccessData: sse_decode_account_info,
-            decodeErrorData: sse_decode_AnyhowException,
-        )), serializer); }
+  @protected
+  void sse_encode_call_state(CallState self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case CallState_Null():
+        sse_encode_i_32(0, serializer);
+      case CallState_Early():
+        sse_encode_i_32(1, serializer);
+      case CallState_Incoming():
+        sse_encode_i_32(2, serializer);
+      case CallState_Calling():
+        sse_encode_i_32(3, serializer);
+      case CallState_Connecting():
+        sse_encode_i_32(4, serializer);
+      case CallState_Confirmed():
+        sse_encode_i_32(5, serializer);
+      case CallState_Disconnected():
+        sse_encode_i_32(6, serializer);
+      case CallState_Error(field0: final field0):
+        sse_encode_i_32(7, serializer);
+        sse_encode_String(field0, serializer);
+    }
+  }
 
-@protected void sse_encode_StreamSink_call_info_Sse(RustStreamSink<CallInfo> self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_String(self.setupAndSerialize(codec: SseCodec(
-            decodeSuccessData: sse_decode_call_info,
-            decodeErrorData: sse_decode_AnyhowException,
-        )), serializer); }
+  @protected
+  void sse_encode_i_32(int self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putInt32(self);
+  }
 
-@protected void sse_encode_String(String self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer); }
+  @protected
+  void sse_encode_i_8(int self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putInt8(self);
+  }
 
-@protected void sse_encode_account_info(AccountInfo self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.accId, serializer);
-sse_encode_i_32(self.statusCode, serializer);
- }
+  @protected
+  void sse_encode_list_prim_u_8_strict(
+    Uint8List self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    serializer.buffer.putUint8List(self);
+  }
 
-@protected void sse_encode_call_info(CallInfo self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.callId, serializer);
-sse_encode_String(self.callUrl, serializer);
-sse_encode_call_state(self.state, serializer);
- }
+  @protected
+  void sse_encode_log_level(LogLevel self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.index, serializer);
+  }
 
-@protected void sse_encode_call_state(CallState self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-switch (self) { case CallState_Null(): sse_encode_i_32(0, serializer); case CallState_Early(): sse_encode_i_32(1, serializer); case CallState_Incoming(): sse_encode_i_32(2, serializer); case CallState_Calling(): sse_encode_i_32(3, serializer); case CallState_Connecting(): sse_encode_i_32(4, serializer); case CallState_Confirmed(): sse_encode_i_32(5, serializer); case CallState_Disconnected(): sse_encode_i_32(6, serializer); case CallState_Error(field0: final field0): sse_encode_i_32(7, serializer); sse_encode_String(field0, serializer);
-  } }
+  @protected
+  void sse_encode_on_incomming_call(
+    OnIncommingCall self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.index, serializer);
+  }
 
-@protected void sse_encode_i_32(int self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-serializer.buffer.putInt32(self); }
+  @protected
+  void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case PJSUAError_CreationError(field0: final field0):
+        sse_encode_i_32(0, serializer);
+        sse_encode_String(field0, serializer);
+      case PJSUAError_ConfigError(field0: final field0):
+        sse_encode_i_32(1, serializer);
+        sse_encode_String(field0, serializer);
+      case PJSUAError_InitializationError(field0: final field0):
+        sse_encode_i_32(2, serializer);
+        sse_encode_String(field0, serializer);
+      case PJSUAError_TransportError(field0: final field0):
+        sse_encode_i_32(3, serializer);
+        sse_encode_String(field0, serializer);
+      case PJSUAError_DTMFError(field0: final field0):
+        sse_encode_i_32(4, serializer);
+        sse_encode_String(field0, serializer);
+      case PJSUAError_CallCreationError(field0: final field0):
+        sse_encode_i_32(5, serializer);
+        sse_encode_String(field0, serializer);
+      case PJSUAError_CallStatusUpdateError(field0: final field0):
+        sse_encode_i_32(6, serializer);
+        sse_encode_String(field0, serializer);
+      case PJSUAError_AccountCreationError(field0: final field0):
+        sse_encode_i_32(7, serializer);
+        sse_encode_String(field0, serializer);
+      case PJSUAError_PJSUAStartError(field0: final field0):
+        sse_encode_i_32(8, serializer);
+        sse_encode_String(field0, serializer);
+      case PJSUAError_PJSUADestroyError(field0: final field0):
+        sse_encode_i_32(9, serializer);
+        sse_encode_String(field0, serializer);
+      case PJSUAError_InputValueError(field0: final field0):
+        sse_encode_i_32(10, serializer);
+        sse_encode_String(field0, serializer);
+    }
+  }
 
-@protected void sse_encode_i_8(int self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-serializer.buffer.putInt8(self); }
+  @protected
+  void sse_encode_u_32(int self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putUint32(self);
+  }
 
-@protected void sse_encode_list_prim_u_8_strict(Uint8List self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.length, serializer);
-                    serializer.buffer.putUint8List(self); }
+  @protected
+  void sse_encode_u_8(int self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putUint8(self);
+  }
 
-@protected void sse_encode_log_level(LogLevel self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.index, serializer); }
+  @protected
+  void sse_encode_unit(void self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+  }
 
-@protected void sse_encode_on_incomming_call(OnIncommingCall self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.index, serializer); }
-
-@protected void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-switch (self) { case PJSUAError_CreationError(field0: final field0): sse_encode_i_32(0, serializer); sse_encode_String(field0, serializer);
-case PJSUAError_ConfigError(field0: final field0): sse_encode_i_32(1, serializer); sse_encode_String(field0, serializer);
-case PJSUAError_InitializationError(field0: final field0): sse_encode_i_32(2, serializer); sse_encode_String(field0, serializer);
-case PJSUAError_TransportError(field0: final field0): sse_encode_i_32(3, serializer); sse_encode_String(field0, serializer);
-case PJSUAError_DTMFError(field0: final field0): sse_encode_i_32(4, serializer); sse_encode_String(field0, serializer);
-case PJSUAError_CallCreationError(field0: final field0): sse_encode_i_32(5, serializer); sse_encode_String(field0, serializer);
-case PJSUAError_CallStatusUpdateError(field0: final field0): sse_encode_i_32(6, serializer); sse_encode_String(field0, serializer);
-case PJSUAError_AccountCreationError(field0: final field0): sse_encode_i_32(7, serializer); sse_encode_String(field0, serializer);
-case PJSUAError_PJSUAStartError(field0: final field0): sse_encode_i_32(8, serializer); sse_encode_String(field0, serializer);
-case PJSUAError_PJSUADestroyError(field0: final field0): sse_encode_i_32(9, serializer); sse_encode_String(field0, serializer);
-case PJSUAError_InputValueError(field0: final field0): sse_encode_i_32(10, serializer); sse_encode_String(field0, serializer);
-  } }
-
-@protected void sse_encode_u_32(int self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-serializer.buffer.putUint32(self); }
-
-@protected void sse_encode_u_8(int self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-serializer.buffer.putUint8(self); }
-
-@protected void sse_encode_unit(void self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
- }
-
-@protected void sse_encode_bool(bool self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-serializer.buffer.putUint8(self ? 1 : 0); }
-                }
-                
+  @protected
+  void sse_encode_bool(bool self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putUint8(self ? 1 : 0);
+  }
+}

--- a/lib/rust/frb_generated.dart
+++ b/lib/rust/frb_generated.dart
@@ -9,896 +9,579 @@ import 'core/types.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart'
-    if (dart.library.js_interop) 'frb_generated.web.dart';
+import 'frb_generated.io.dart' if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-/// Main entrypoint of the Rust API
-class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
-  @internal
-  static final instance = RustLib._();
 
-  RustLib._();
+                /// Main entrypoint of the Rust API
+                class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
+                  @internal
+                  static final instance = RustLib._();
 
-  /// Initialize flutter_rust_bridge
-  static Future<void> init({
-    RustLibApi? api,
-    BaseHandler? handler,
-    ExternalLibrary? externalLibrary,
-    bool forceSameCodegenVersion = true,
-  }) async {
-    await instance.initImpl(
-      api: api,
-      handler: handler,
-      externalLibrary: externalLibrary,
-      forceSameCodegenVersion: forceSameCodegenVersion,
-    );
-  }
+                  RustLib._();
 
-  /// Initialize flutter_rust_bridge in mock mode.
-  /// No libraries for FFI are loaded.
-  static void initMock({required RustLibApi api}) {
-    instance.initMockImpl(api: api);
-  }
+                  /// Initialize flutter_rust_bridge
+                  static Future<void> init({
+                    RustLibApi? api,
+                    BaseHandler? handler,
+                    ExternalLibrary? externalLibrary,
+                    bool forceSameCodegenVersion = true,
+                  }) async {
+                    await instance.initImpl(
+                      api: api,
+                      handler: handler,
+                      externalLibrary: externalLibrary,
+                      forceSameCodegenVersion: forceSameCodegenVersion,
+                    );
+                  }
 
-  /// Dispose flutter_rust_bridge
-  ///
-  /// The call to this function is optional, since flutter_rust_bridge (and everything else)
-  /// is automatically disposed when the app stops.
-  static void dispose() => instance.disposeImpl();
+                  /// Initialize flutter_rust_bridge in mock mode.
+                  /// No libraries for FFI are loaded.
+                  static void initMock({
+                    required RustLibApi api,
+                  }) {
+                    instance.initMockImpl(
+                      api: api,
+                    );
+                  }
 
-  @override
-  ApiImplConstructor<RustLibApiImpl, RustLibWire> get apiImplConstructor =>
-      RustLibApiImpl.new;
+                  /// Dispose flutter_rust_bridge
+                  ///
+                  /// The call to this function is optional, since flutter_rust_bridge (and everything else)
+                  /// is automatically disposed when the app stops.
+                  static void dispose() => instance.disposeImpl();
 
-  @override
-  WireConstructor<RustLibWire> get wireConstructor =>
-      RustLibWire.fromExternalLibrary;
+                  @override
+                  ApiImplConstructor<RustLibApiImpl, RustLibWire> get apiImplConstructor => RustLibApiImpl.new;
 
-  @override
-  Future<void> executeRustInitializers() async {
-    await api.crateApiSimpleInitApp();
-  }
+                  @override
+                  WireConstructor<RustLibWire> get wireConstructor => RustLibWire.fromExternalLibrary;
 
-  @override
-  ExternalLibraryLoaderConfig get defaultExternalLibraryLoaderConfig =>
-      kDefaultExternalLibraryLoaderConfig;
+                  @override
+                  Future<void> executeRustInitializers() async {
+                    await api.crateApiSimpleInitApp();
 
-  @override
-  String get codegenVersion => '2.11.1';
+                  }
 
-  @override
-  int get rustContentHash => -175070977;
+                  @override
+                  ExternalLibraryLoaderConfig get defaultExternalLibraryLoaderConfig => kDefaultExternalLibraryLoaderConfig;
 
-  static const kDefaultExternalLibraryLoaderConfig =
-      ExternalLibraryLoaderConfig(
-        stem: 'flutter_rust_sip',
-        ioDirectory: 'rust/target/release/',
-        webPrefix: 'pkg/',
-      );
-}
+                  @override
+                  String get codegenVersion => '2.11.1';
 
-abstract class RustLibApi extends BaseApi {
-  Future<int> crateApiSimpleAccountSetup({
-    required String uri,
-    required String username,
-    required String password,
-  });
+                  @override
+                  int get rustContentHash => -175070977;
 
-  Future<int> crateApiSimpleDestroyPjsua();
+                  static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
+                    stem: 'flutter_rust_sip',
+                    ioDirectory: 'rust/target/release/',
+                    webPrefix: 'pkg/',
+                  );
+                }
+                
 
-  Future<void> crateApiSimpleHangupCall({required int callId});
+                abstract class RustLibApi extends BaseApi {
+                  Future<int> crateApiSimpleAccountSetup({required String uri , required String username , required String password });
 
-  Future<void> crateApiSimpleInitApp();
+Future<int> crateApiSimpleDestroyPjsua();
 
-  Future<int> crateApiSimpleInitPjsua({
-    required int localPort,
-    required OnIncommingCall incomingCallStrategy,
-    required String stunSrv,
-  });
+Future<void> crateApiSimpleHangupCall({required int callId });
 
-  Future<int> crateApiSimpleMakeCall({
-    required String phoneNumber,
-    required String domain,
-  });
+Future<void> crateApiSimpleInitApp();
 
-  Future<void> crateApiSimpleMarkCallAlive({required int callId});
+Future<int> crateApiSimpleInitPjsua({required int localPort , required OnIncommingCall incomingCallStrategy , required String stunSrv , required LogLevel logLevel });
 
-  Stream<AccountInfo> crateApiSimpleRegisterAccountStream();
+Future<int> crateApiSimpleMakeCall({required String phoneNumber , required String domain });
 
-  Stream<CallInfo> crateApiSimpleRegisterCallStream();
-}
+Future<void> crateApiSimpleMarkCallAlive({required int callId });
 
-class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
-  RustLibApiImpl({
-    required super.handler,
-    required super.wire,
-    required super.generalizedFrbRustBinding,
-    required super.portManager,
-  });
+Stream<AccountInfo> crateApiSimpleRegisterAccountStream();
 
-  @override
-  Future<int> crateApiSimpleAccountSetup({
-    required String uri,
-    required String username,
-    required String password,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(uri, serializer);
-          sse_encode_String(username, serializer);
-          sse_encode_String(password, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 1,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
+Stream<CallInfo> crateApiSimpleRegisterCallStream();
+
+
+                }
+                
+
+                class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
+                  RustLibApiImpl({
+                    required super.handler,
+                    required super.wire,
+                    required super.generalizedFrbRustBinding,
+                    required super.portManager,
+                  });
+
+                  @override Future<int> crateApiSimpleAccountSetup({required String uri , required String username , required String password })  { return handler.executeNormal(NormalTask(
+            callFfi: (port_) {
+              
+            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_String(uri, serializer);
+sse_encode_String(username, serializer);
+sse_encode_String(password, serializer);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1, port: port_);
+            
+            },
+            codec: 
+        SseCodec(
           decodeSuccessData: sse_decode_i_32,
           decodeErrorData: sse_decode_pjsua_error,
-        ),
-        constMeta: kCrateApiSimpleAccountSetupConstMeta,
-        argValues: [uri, username, password],
-        apiImpl: this,
-      ),
-    );
-  }
+        )
+        ,
+            constMeta: kCrateApiSimpleAccountSetupConstMeta,
+            argValues: [uri, username, password],
+            apiImpl: this,
+        )); }
 
-  TaskConstMeta get kCrateApiSimpleAccountSetupConstMeta => const TaskConstMeta(
-    debugName: "account_setup",
-    argNames: ["uri", "username", "password"],
-  );
 
-  @override
-  Future<int> crateApiSimpleDestroyPjsua() {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 2,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
+        TaskConstMeta get kCrateApiSimpleAccountSetupConstMeta => const TaskConstMeta(
+            debugName: "account_setup",
+            argNames: ["uri", "username", "password"],
+        );
+        
+
+@override Future<int> crateApiSimpleDestroyPjsua()  { return handler.executeNormal(NormalTask(
+            callFfi: (port_) {
+              
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2, port: port_);
+            
+            },
+            codec: 
+        SseCodec(
           decodeSuccessData: sse_decode_i_8,
           decodeErrorData: sse_decode_pjsua_error,
-        ),
-        constMeta: kCrateApiSimpleDestroyPjsuaConstMeta,
-        argValues: [],
-        apiImpl: this,
-      ),
-    );
-  }
+        )
+        ,
+            constMeta: kCrateApiSimpleDestroyPjsuaConstMeta,
+            argValues: [],
+            apiImpl: this,
+        )); }
 
-  TaskConstMeta get kCrateApiSimpleDestroyPjsuaConstMeta =>
-      const TaskConstMeta(debugName: "destroy_pjsua", argNames: []);
 
-  @override
-  Future<void> crateApiSimpleHangupCall({required int callId}) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_i_32(callId, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 3,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
+        TaskConstMeta get kCrateApiSimpleDestroyPjsuaConstMeta => const TaskConstMeta(
+            debugName: "destroy_pjsua",
+            argNames: [],
+        );
+        
+
+@override Future<void> crateApiSimpleHangupCall({required int callId })  { return handler.executeNormal(NormalTask(
+            callFfi: (port_) {
+              
+            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_i_32(callId, serializer);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 3, port: port_);
+            
+            },
+            codec: 
+        SseCodec(
           decodeSuccessData: sse_decode_unit,
           decodeErrorData: sse_decode_pjsua_error,
-        ),
-        constMeta: kCrateApiSimpleHangupCallConstMeta,
-        argValues: [callId],
-        apiImpl: this,
-      ),
-    );
-  }
+        )
+        ,
+            constMeta: kCrateApiSimpleHangupCallConstMeta,
+            argValues: [callId],
+            apiImpl: this,
+        )); }
 
-  TaskConstMeta get kCrateApiSimpleHangupCallConstMeta =>
-      const TaskConstMeta(debugName: "hangup_call", argNames: ["callId"]);
 
-  @override
-  Future<void> crateApiSimpleInitApp() {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 4,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
+        TaskConstMeta get kCrateApiSimpleHangupCallConstMeta => const TaskConstMeta(
+            debugName: "hangup_call",
+            argNames: ["callId"],
+        );
+        
+
+@override Future<void> crateApiSimpleInitApp()  { return handler.executeNormal(NormalTask(
+            callFfi: (port_) {
+              
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4, port: port_);
+            
+            },
+            codec: 
+        SseCodec(
           decodeSuccessData: sse_decode_unit,
           decodeErrorData: null,
-        ),
-        constMeta: kCrateApiSimpleInitAppConstMeta,
-        argValues: [],
-        apiImpl: this,
-      ),
-    );
-  }
+        )
+        ,
+            constMeta: kCrateApiSimpleInitAppConstMeta,
+            argValues: [],
+            apiImpl: this,
+        )); }
 
-  TaskConstMeta get kCrateApiSimpleInitAppConstMeta =>
-      const TaskConstMeta(debugName: "init_app", argNames: []);
 
-  @override
-  Future<int> crateApiSimpleInitPjsua({
-    required int localPort,
-    required OnIncommingCall incomingCallStrategy,
-    required String stunSrv,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_u_32(localPort, serializer);
-          sse_encode_on_incomming_call(incomingCallStrategy, serializer);
-          sse_encode_String(stunSrv, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 5,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
+        TaskConstMeta get kCrateApiSimpleInitAppConstMeta => const TaskConstMeta(
+            debugName: "init_app",
+            argNames: [],
+        );
+        
+
+@override Future<int> crateApiSimpleInitPjsua({required int localPort , required OnIncommingCall incomingCallStrategy , required String stunSrv , required LogLevel logLevel })  { return handler.executeNormal(NormalTask(
+            callFfi: (port_) {
+              
+            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_u_32(localPort, serializer);
+sse_encode_on_incomming_call(incomingCallStrategy, serializer);
+sse_encode_String(stunSrv, serializer);
+sse_encode_log_level(logLevel, serializer);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5, port: port_);
+            
+            },
+            codec: 
+        SseCodec(
           decodeSuccessData: sse_decode_i_8,
           decodeErrorData: sse_decode_pjsua_error,
-        ),
-        constMeta: kCrateApiSimpleInitPjsuaConstMeta,
-        argValues: [localPort, incomingCallStrategy, stunSrv],
-        apiImpl: this,
-      ),
-    );
-  }
+        )
+        ,
+            constMeta: kCrateApiSimpleInitPjsuaConstMeta,
+            argValues: [localPort, incomingCallStrategy, stunSrv, logLevel],
+            apiImpl: this,
+        )); }
 
-  TaskConstMeta get kCrateApiSimpleInitPjsuaConstMeta => const TaskConstMeta(
-    debugName: "init_pjsua",
-    argNames: ["localPort", "incomingCallStrategy", "stunSrv"],
-  );
 
-  @override
-  Future<int> crateApiSimpleMakeCall({
-    required String phoneNumber,
-    required String domain,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(phoneNumber, serializer);
-          sse_encode_String(domain, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 6,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
+        TaskConstMeta get kCrateApiSimpleInitPjsuaConstMeta => const TaskConstMeta(
+            debugName: "init_pjsua",
+            argNames: ["localPort", "incomingCallStrategy", "stunSrv", "logLevel"],
+        );
+        
+
+@override Future<int> crateApiSimpleMakeCall({required String phoneNumber , required String domain })  { return handler.executeNormal(NormalTask(
+            callFfi: (port_) {
+              
+            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_String(phoneNumber, serializer);
+sse_encode_String(domain, serializer);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6, port: port_);
+            
+            },
+            codec: 
+        SseCodec(
           decodeSuccessData: sse_decode_i_32,
           decodeErrorData: sse_decode_pjsua_error,
-        ),
-        constMeta: kCrateApiSimpleMakeCallConstMeta,
-        argValues: [phoneNumber, domain],
-        apiImpl: this,
-      ),
-    );
-  }
+        )
+        ,
+            constMeta: kCrateApiSimpleMakeCallConstMeta,
+            argValues: [phoneNumber, domain],
+            apiImpl: this,
+        )); }
 
-  TaskConstMeta get kCrateApiSimpleMakeCallConstMeta => const TaskConstMeta(
-    debugName: "make_call",
-    argNames: ["phoneNumber", "domain"],
-  );
 
-  @override
-  Future<void> crateApiSimpleMarkCallAlive({required int callId}) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_i_32(callId, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 7,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
+        TaskConstMeta get kCrateApiSimpleMakeCallConstMeta => const TaskConstMeta(
+            debugName: "make_call",
+            argNames: ["phoneNumber", "domain"],
+        );
+        
+
+@override Future<void> crateApiSimpleMarkCallAlive({required int callId })  { return handler.executeNormal(NormalTask(
+            callFfi: (port_) {
+              
+            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_i_32(callId, serializer);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7, port: port_);
+            
+            },
+            codec: 
+        SseCodec(
           decodeSuccessData: sse_decode_unit,
           decodeErrorData: null,
-        ),
-        constMeta: kCrateApiSimpleMarkCallAliveConstMeta,
-        argValues: [callId],
-        apiImpl: this,
-      ),
-    );
-  }
+        )
+        ,
+            constMeta: kCrateApiSimpleMarkCallAliveConstMeta,
+            argValues: [callId],
+            apiImpl: this,
+        )); }
 
-  TaskConstMeta get kCrateApiSimpleMarkCallAliveConstMeta =>
-      const TaskConstMeta(debugName: "mark_call_alive", argNames: ["callId"]);
 
-  @override
-  Stream<AccountInfo> crateApiSimpleRegisterAccountStream() {
-    final accountSink = RustStreamSink<AccountInfo>();
-    unawaited(
-      handler.executeNormal(
-        NormalTask(
-          callFfi: (port_) {
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            sse_encode_StreamSink_account_info_Sse(accountSink, serializer);
-            pdeCallFfi(
-              generalizedFrbRustBinding,
-              serializer,
-              funcId: 8,
-              port: port_,
-            );
-          },
-          codec: SseCodec(
-            decodeSuccessData: sse_decode_unit,
-            decodeErrorData: null,
-          ),
-          constMeta: kCrateApiSimpleRegisterAccountStreamConstMeta,
-          argValues: [accountSink],
-          apiImpl: this,
-        ),
-      ),
-    );
-    return accountSink.stream;
-  }
+        TaskConstMeta get kCrateApiSimpleMarkCallAliveConstMeta => const TaskConstMeta(
+            debugName: "mark_call_alive",
+            argNames: ["callId"],
+        );
+        
 
-  TaskConstMeta get kCrateApiSimpleRegisterAccountStreamConstMeta =>
-      const TaskConstMeta(
-        debugName: "register_account_stream",
-        argNames: ["accountSink"],
-      );
+@override Stream<AccountInfo> crateApiSimpleRegisterAccountStream()  { 
+            final accountSink = RustStreamSink<AccountInfo>();
+            unawaited(handler.executeNormal(NormalTask(
+            callFfi: (port_) {
+              
+            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_StreamSink_account_info_Sse(accountSink, serializer);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8, port: port_);
+            
+            },
+            codec: 
+        SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        )
+        ,
+            constMeta: kCrateApiSimpleRegisterAccountStreamConstMeta,
+            argValues: [accountSink],
+            apiImpl: this,
+        )));
+            return accountSink.stream;
+             }
 
-  @override
-  Stream<CallInfo> crateApiSimpleRegisterCallStream() {
-    final callSink = RustStreamSink<CallInfo>();
-    unawaited(
-      handler.executeNormal(
-        NormalTask(
-          callFfi: (port_) {
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            sse_encode_StreamSink_call_info_Sse(callSink, serializer);
-            pdeCallFfi(
-              generalizedFrbRustBinding,
-              serializer,
-              funcId: 9,
-              port: port_,
-            );
-          },
-          codec: SseCodec(
-            decodeSuccessData: sse_decode_unit,
-            decodeErrorData: null,
-          ),
-          constMeta: kCrateApiSimpleRegisterCallStreamConstMeta,
-          argValues: [callSink],
-          apiImpl: this,
-        ),
-      ),
-    );
-    return callSink.stream;
-  }
 
-  TaskConstMeta get kCrateApiSimpleRegisterCallStreamConstMeta =>
-      const TaskConstMeta(
-        debugName: "register_call_stream",
-        argNames: ["callSink"],
-      );
+        TaskConstMeta get kCrateApiSimpleRegisterAccountStreamConstMeta => const TaskConstMeta(
+            debugName: "register_account_stream",
+            argNames: ["accountSink"],
+        );
+        
 
-  @protected
-  AnyhowException dco_decode_AnyhowException(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AnyhowException(raw as String);
-  }
+@override Stream<CallInfo> crateApiSimpleRegisterCallStream()  { 
+            final callSink = RustStreamSink<CallInfo>();
+            unawaited(handler.executeNormal(NormalTask(
+            callFfi: (port_) {
+              
+            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_StreamSink_call_info_Sse(callSink, serializer);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9, port: port_);
+            
+            },
+            codec: 
+        SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        )
+        ,
+            constMeta: kCrateApiSimpleRegisterCallStreamConstMeta,
+            argValues: [callSink],
+            apiImpl: this,
+        )));
+            return callSink.stream;
+             }
 
-  @protected
-  RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    throw UnimplementedError();
-  }
 
-  @protected
-  RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    throw UnimplementedError();
-  }
+        TaskConstMeta get kCrateApiSimpleRegisterCallStreamConstMeta => const TaskConstMeta(
+            debugName: "register_call_stream",
+            argNames: ["callSink"],
+        );
+        
 
-  @protected
-  String dco_decode_String(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
-  }
 
-  @protected
-  AccountInfo dco_decode_account_info(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-    return AccountInfo(
-      accId: dco_decode_i_32(arr[0]),
-      statusCode: dco_decode_i_32(arr[1]),
-    );
-  }
 
-  @protected
-  CallInfo dco_decode_call_info(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 3)
-      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
-    return CallInfo(
-      callId: dco_decode_i_32(arr[0]),
-      callUrl: dco_decode_String(arr[1]),
-      state: dco_decode_call_state(arr[2]),
-    );
-  }
+                  @protected AnyhowException dco_decode_AnyhowException(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+return AnyhowException(raw as String); }
 
-  @protected
-  CallState dco_decode_call_state(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
-      case 0:
-        return CallState_Null();
-      case 1:
-        return CallState_Early();
-      case 2:
-        return CallState_Incoming();
-      case 3:
-        return CallState_Calling();
-      case 4:
-        return CallState_Connecting();
-      case 5:
-        return CallState_Confirmed();
-      case 6:
-        return CallState_Disconnected();
-      case 7:
-        return CallState_Error(dco_decode_String(raw[1]));
-      default:
-        throw Exception("unreachable");
-    }
-  }
+@protected RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+throw UnimplementedError(); }
 
-  @protected
-  int dco_decode_i_32(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
-  }
+@protected RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+throw UnimplementedError(); }
 
-  @protected
-  int dco_decode_i_8(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
-  }
+@protected String dco_decode_String(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+return raw as String; }
 
-  @protected
-  Uint8List dco_decode_list_prim_u_8_strict(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as Uint8List;
-  }
+@protected AccountInfo dco_decode_account_info(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+final arr = raw as List<dynamic>;
+                if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+                return AccountInfo(accId: dco_decode_i_32(arr[0]),
+statusCode: dco_decode_i_32(arr[1]),); }
 
-  @protected
-  OnIncommingCall dco_decode_on_incomming_call(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OnIncommingCall.values[raw as int];
-  }
+@protected CallInfo dco_decode_call_info(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+final arr = raw as List<dynamic>;
+                if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+                return CallInfo(callId: dco_decode_i_32(arr[0]),
+callUrl: dco_decode_String(arr[1]),
+state: dco_decode_call_state(arr[2]),); }
 
-  @protected
-  PJSUAError dco_decode_pjsua_error(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
-      case 0:
-        return PJSUAError_CreationError(dco_decode_String(raw[1]));
-      case 1:
-        return PJSUAError_ConfigError(dco_decode_String(raw[1]));
-      case 2:
-        return PJSUAError_InitializationError(dco_decode_String(raw[1]));
-      case 3:
-        return PJSUAError_TransportError(dco_decode_String(raw[1]));
-      case 4:
-        return PJSUAError_DTMFError(dco_decode_String(raw[1]));
-      case 5:
-        return PJSUAError_CallCreationError(dco_decode_String(raw[1]));
-      case 6:
-        return PJSUAError_CallStatusUpdateError(dco_decode_String(raw[1]));
-      case 7:
-        return PJSUAError_AccountCreationError(dco_decode_String(raw[1]));
-      case 8:
-        return PJSUAError_PJSUAStartError(dco_decode_String(raw[1]));
-      case 9:
-        return PJSUAError_PJSUADestroyError(dco_decode_String(raw[1]));
-      case 10:
-        return PJSUAError_InputValueError(dco_decode_String(raw[1]));
-      default:
-        throw Exception("unreachable");
-    }
-  }
+@protected CallState dco_decode_call_state(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+switch (raw[0]) {
+                case 0: return CallState_Null();
+case 1: return CallState_Early();
+case 2: return CallState_Incoming();
+case 3: return CallState_Calling();
+case 4: return CallState_Connecting();
+case 5: return CallState_Confirmed();
+case 6: return CallState_Disconnected();
+case 7: return CallState_Error(dco_decode_String(raw[1]),);
+                default: throw Exception("unreachable");
+            } }
 
-  @protected
-  int dco_decode_u_32(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
-  }
+@protected int dco_decode_i_32(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+return raw as int; }
 
-  @protected
-  int dco_decode_u_8(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
-  }
+@protected int dco_decode_i_8(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+return raw as int; }
 
-  @protected
-  void dco_decode_unit(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return;
-  }
+@protected Uint8List dco_decode_list_prim_u_8_strict(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+return raw as Uint8List; }
 
-  @protected
-  AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var inner = sse_decode_String(deserializer);
-    return AnyhowException(inner);
-  }
+@protected LogLevel dco_decode_log_level(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+return LogLevel.values[raw as int]; }
 
-  @protected
-  RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    throw UnimplementedError('Unreachable ()');
-  }
+@protected OnIncommingCall dco_decode_on_incomming_call(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+return OnIncommingCall.values[raw as int]; }
 
-  @protected
-  RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    throw UnimplementedError('Unreachable ()');
-  }
+@protected PJSUAError dco_decode_pjsua_error(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+switch (raw[0]) {
+                case 0: return PJSUAError_CreationError(dco_decode_String(raw[1]),);
+case 1: return PJSUAError_ConfigError(dco_decode_String(raw[1]),);
+case 2: return PJSUAError_InitializationError(dco_decode_String(raw[1]),);
+case 3: return PJSUAError_TransportError(dco_decode_String(raw[1]),);
+case 4: return PJSUAError_DTMFError(dco_decode_String(raw[1]),);
+case 5: return PJSUAError_CallCreationError(dco_decode_String(raw[1]),);
+case 6: return PJSUAError_CallStatusUpdateError(dco_decode_String(raw[1]),);
+case 7: return PJSUAError_AccountCreationError(dco_decode_String(raw[1]),);
+case 8: return PJSUAError_PJSUAStartError(dco_decode_String(raw[1]),);
+case 9: return PJSUAError_PJSUADestroyError(dco_decode_String(raw[1]),);
+case 10: return PJSUAError_InputValueError(dco_decode_String(raw[1]),);
+                default: throw Exception("unreachable");
+            } }
 
-  @protected
-  String sse_decode_String(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var inner = sse_decode_list_prim_u_8_strict(deserializer);
-    return utf8.decoder.convert(inner);
-  }
+@protected int dco_decode_u_32(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+return raw as int; }
 
-  @protected
-  AccountInfo sse_decode_account_info(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_accId = sse_decode_i_32(deserializer);
-    var var_statusCode = sse_decode_i_32(deserializer);
-    return AccountInfo(accId: var_accId, statusCode: var_statusCode);
-  }
+@protected int dco_decode_u_8(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+return raw as int; }
 
-  @protected
-  CallInfo sse_decode_call_info(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_callId = sse_decode_i_32(deserializer);
-    var var_callUrl = sse_decode_String(deserializer);
-    var var_state = sse_decode_call_state(deserializer);
-    return CallInfo(callId: var_callId, callUrl: var_callUrl, state: var_state);
-  }
+@protected void dco_decode_unit(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
+return; }
 
-  @protected
-  CallState sse_decode_call_state(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
+@protected AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+var inner = sse_decode_String(deserializer);
+        return AnyhowException(inner); }
 
-    var tag_ = sse_decode_i_32(deserializer);
-    switch (tag_) {
-      case 0:
-        return CallState_Null();
-      case 1:
-        return CallState_Early();
-      case 2:
-        return CallState_Incoming();
-      case 3:
-        return CallState_Calling();
-      case 4:
-        return CallState_Connecting();
-      case 5:
-        return CallState_Confirmed();
-      case 6:
-        return CallState_Disconnected();
-      case 7:
-        var var_field0 = sse_decode_String(deserializer);
-        return CallState_Error(var_field0);
-      default:
-        throw UnimplementedError('');
-    }
-  }
+@protected RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+throw UnimplementedError('Unreachable ()'); }
 
-  @protected
-  int sse_decode_i_32(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return deserializer.buffer.getInt32();
-  }
+@protected RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+throw UnimplementedError('Unreachable ()'); }
 
-  @protected
-  int sse_decode_i_8(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return deserializer.buffer.getInt8();
-  }
+@protected String sse_decode_String(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+var inner = sse_decode_list_prim_u_8_strict(deserializer);
+        return utf8.decoder.convert(inner); }
 
-  @protected
-  Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var len_ = sse_decode_i_32(deserializer);
-    return deserializer.buffer.getUint8List(len_);
-  }
+@protected AccountInfo sse_decode_account_info(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+var var_accId = sse_decode_i_32(deserializer);
+var var_statusCode = sse_decode_i_32(deserializer);
+return AccountInfo(accId: var_accId, statusCode: var_statusCode); }
 
-  @protected
-  OnIncommingCall sse_decode_on_incomming_call(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var inner = sse_decode_i_32(deserializer);
-    return OnIncommingCall.values[inner];
-  }
+@protected CallInfo sse_decode_call_info(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+var var_callId = sse_decode_i_32(deserializer);
+var var_callUrl = sse_decode_String(deserializer);
+var var_state = sse_decode_call_state(deserializer);
+return CallInfo(callId: var_callId, callUrl: var_callUrl, state: var_state); }
 
-  @protected
-  PJSUAError sse_decode_pjsua_error(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
+@protected CallState sse_decode_call_state(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
 
-    var tag_ = sse_decode_i_32(deserializer);
-    switch (tag_) {
-      case 0:
-        var var_field0 = sse_decode_String(deserializer);
-        return PJSUAError_CreationError(var_field0);
-      case 1:
-        var var_field0 = sse_decode_String(deserializer);
-        return PJSUAError_ConfigError(var_field0);
-      case 2:
-        var var_field0 = sse_decode_String(deserializer);
-        return PJSUAError_InitializationError(var_field0);
-      case 3:
-        var var_field0 = sse_decode_String(deserializer);
-        return PJSUAError_TransportError(var_field0);
-      case 4:
-        var var_field0 = sse_decode_String(deserializer);
-        return PJSUAError_DTMFError(var_field0);
-      case 5:
-        var var_field0 = sse_decode_String(deserializer);
-        return PJSUAError_CallCreationError(var_field0);
-      case 6:
-        var var_field0 = sse_decode_String(deserializer);
-        return PJSUAError_CallStatusUpdateError(var_field0);
-      case 7:
-        var var_field0 = sse_decode_String(deserializer);
-        return PJSUAError_AccountCreationError(var_field0);
-      case 8:
-        var var_field0 = sse_decode_String(deserializer);
-        return PJSUAError_PJSUAStartError(var_field0);
-      case 9:
-        var var_field0 = sse_decode_String(deserializer);
-        return PJSUAError_PJSUADestroyError(var_field0);
-      case 10:
-        var var_field0 = sse_decode_String(deserializer);
-        return PJSUAError_InputValueError(var_field0);
-      default:
-        throw UnimplementedError('');
-    }
-  }
+            var tag_ = sse_decode_i_32(deserializer);
+            switch (tag_) { case 0: return CallState_Null();case 1: return CallState_Early();case 2: return CallState_Incoming();case 3: return CallState_Calling();case 4: return CallState_Connecting();case 5: return CallState_Confirmed();case 6: return CallState_Disconnected();case 7: var var_field0 = sse_decode_String(deserializer);
+return CallState_Error(var_field0); default: throw UnimplementedError(''); }
+             }
 
-  @protected
-  int sse_decode_u_32(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return deserializer.buffer.getUint32();
-  }
+@protected int sse_decode_i_32(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+return deserializer.buffer.getInt32(); }
 
-  @protected
-  int sse_decode_u_8(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return deserializer.buffer.getUint8();
-  }
+@protected int sse_decode_i_8(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+return deserializer.buffer.getInt8(); }
 
-  @protected
-  void sse_decode_unit(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-  }
+@protected Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+var len_ = sse_decode_i_32(deserializer);
+                return deserializer.buffer.getUint8List(len_); }
 
-  @protected
-  bool sse_decode_bool(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return deserializer.buffer.getUint8() != 0;
-  }
+@protected LogLevel sse_decode_log_level(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+var inner = sse_decode_i_32(deserializer);
+        return LogLevel.values[inner]; }
 
-  @protected
-  void sse_encode_AnyhowException(
-    AnyhowException self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.message, serializer);
-  }
+@protected OnIncommingCall sse_decode_on_incomming_call(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+var inner = sse_decode_i_32(deserializer);
+        return OnIncommingCall.values[inner]; }
 
-  @protected
-  void sse_encode_StreamSink_account_info_Sse(
-    RustStreamSink<AccountInfo> self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(
-      self.setupAndSerialize(
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_account_info,
-          decodeErrorData: sse_decode_AnyhowException,
-        ),
-      ),
-      serializer,
-    );
-  }
+@protected PJSUAError sse_decode_pjsua_error(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
 
-  @protected
-  void sse_encode_StreamSink_call_info_Sse(
-    RustStreamSink<CallInfo> self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(
-      self.setupAndSerialize(
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_call_info,
-          decodeErrorData: sse_decode_AnyhowException,
-        ),
-      ),
-      serializer,
-    );
-  }
+            var tag_ = sse_decode_i_32(deserializer);
+            switch (tag_) { case 0: var var_field0 = sse_decode_String(deserializer);
+return PJSUAError_CreationError(var_field0);case 1: var var_field0 = sse_decode_String(deserializer);
+return PJSUAError_ConfigError(var_field0);case 2: var var_field0 = sse_decode_String(deserializer);
+return PJSUAError_InitializationError(var_field0);case 3: var var_field0 = sse_decode_String(deserializer);
+return PJSUAError_TransportError(var_field0);case 4: var var_field0 = sse_decode_String(deserializer);
+return PJSUAError_DTMFError(var_field0);case 5: var var_field0 = sse_decode_String(deserializer);
+return PJSUAError_CallCreationError(var_field0);case 6: var var_field0 = sse_decode_String(deserializer);
+return PJSUAError_CallStatusUpdateError(var_field0);case 7: var var_field0 = sse_decode_String(deserializer);
+return PJSUAError_AccountCreationError(var_field0);case 8: var var_field0 = sse_decode_String(deserializer);
+return PJSUAError_PJSUAStartError(var_field0);case 9: var var_field0 = sse_decode_String(deserializer);
+return PJSUAError_PJSUADestroyError(var_field0);case 10: var var_field0 = sse_decode_String(deserializer);
+return PJSUAError_InputValueError(var_field0); default: throw UnimplementedError(''); }
+             }
 
-  @protected
-  void sse_encode_String(String self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer);
-  }
+@protected int sse_decode_u_32(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+return deserializer.buffer.getUint32(); }
 
-  @protected
-  void sse_encode_account_info(AccountInfo self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_i_32(self.accId, serializer);
-    sse_encode_i_32(self.statusCode, serializer);
-  }
+@protected int sse_decode_u_8(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+return deserializer.buffer.getUint8(); }
 
-  @protected
-  void sse_encode_call_info(CallInfo self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_i_32(self.callId, serializer);
-    sse_encode_String(self.callUrl, serializer);
-    sse_encode_call_state(self.state, serializer);
-  }
+@protected void sse_decode_unit(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+ }
 
-  @protected
-  void sse_encode_call_state(CallState self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    switch (self) {
-      case CallState_Null():
-        sse_encode_i_32(0, serializer);
-      case CallState_Early():
-        sse_encode_i_32(1, serializer);
-      case CallState_Incoming():
-        sse_encode_i_32(2, serializer);
-      case CallState_Calling():
-        sse_encode_i_32(3, serializer);
-      case CallState_Connecting():
-        sse_encode_i_32(4, serializer);
-      case CallState_Confirmed():
-        sse_encode_i_32(5, serializer);
-      case CallState_Disconnected():
-        sse_encode_i_32(6, serializer);
-      case CallState_Error(field0: final field0):
-        sse_encode_i_32(7, serializer);
-        sse_encode_String(field0, serializer);
-    }
-  }
+@protected bool sse_decode_bool(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+return deserializer.buffer.getUint8() != 0; }
 
-  @protected
-  void sse_encode_i_32(int self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    serializer.buffer.putInt32(self);
-  }
+@protected void sse_encode_AnyhowException(AnyhowException self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+sse_encode_String(self.message, serializer); }
 
-  @protected
-  void sse_encode_i_8(int self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    serializer.buffer.putInt8(self);
-  }
+@protected void sse_encode_StreamSink_account_info_Sse(RustStreamSink<AccountInfo> self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+sse_encode_String(self.setupAndSerialize(codec: SseCodec(
+            decodeSuccessData: sse_decode_account_info,
+            decodeErrorData: sse_decode_AnyhowException,
+        )), serializer); }
 
-  @protected
-  void sse_encode_list_prim_u_8_strict(
-    Uint8List self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_i_32(self.length, serializer);
-    serializer.buffer.putUint8List(self);
-  }
+@protected void sse_encode_StreamSink_call_info_Sse(RustStreamSink<CallInfo> self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+sse_encode_String(self.setupAndSerialize(codec: SseCodec(
+            decodeSuccessData: sse_decode_call_info,
+            decodeErrorData: sse_decode_AnyhowException,
+        )), serializer); }
 
-  @protected
-  void sse_encode_on_incomming_call(
-    OnIncommingCall self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_i_32(self.index, serializer);
-  }
+@protected void sse_encode_String(String self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer); }
 
-  @protected
-  void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    switch (self) {
-      case PJSUAError_CreationError(field0: final field0):
-        sse_encode_i_32(0, serializer);
-        sse_encode_String(field0, serializer);
-      case PJSUAError_ConfigError(field0: final field0):
-        sse_encode_i_32(1, serializer);
-        sse_encode_String(field0, serializer);
-      case PJSUAError_InitializationError(field0: final field0):
-        sse_encode_i_32(2, serializer);
-        sse_encode_String(field0, serializer);
-      case PJSUAError_TransportError(field0: final field0):
-        sse_encode_i_32(3, serializer);
-        sse_encode_String(field0, serializer);
-      case PJSUAError_DTMFError(field0: final field0):
-        sse_encode_i_32(4, serializer);
-        sse_encode_String(field0, serializer);
-      case PJSUAError_CallCreationError(field0: final field0):
-        sse_encode_i_32(5, serializer);
-        sse_encode_String(field0, serializer);
-      case PJSUAError_CallStatusUpdateError(field0: final field0):
-        sse_encode_i_32(6, serializer);
-        sse_encode_String(field0, serializer);
-      case PJSUAError_AccountCreationError(field0: final field0):
-        sse_encode_i_32(7, serializer);
-        sse_encode_String(field0, serializer);
-      case PJSUAError_PJSUAStartError(field0: final field0):
-        sse_encode_i_32(8, serializer);
-        sse_encode_String(field0, serializer);
-      case PJSUAError_PJSUADestroyError(field0: final field0):
-        sse_encode_i_32(9, serializer);
-        sse_encode_String(field0, serializer);
-      case PJSUAError_InputValueError(field0: final field0):
-        sse_encode_i_32(10, serializer);
-        sse_encode_String(field0, serializer);
-    }
-  }
+@protected void sse_encode_account_info(AccountInfo self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+sse_encode_i_32(self.accId, serializer);
+sse_encode_i_32(self.statusCode, serializer);
+ }
 
-  @protected
-  void sse_encode_u_32(int self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    serializer.buffer.putUint32(self);
-  }
+@protected void sse_encode_call_info(CallInfo self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+sse_encode_i_32(self.callId, serializer);
+sse_encode_String(self.callUrl, serializer);
+sse_encode_call_state(self.state, serializer);
+ }
 
-  @protected
-  void sse_encode_u_8(int self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    serializer.buffer.putUint8(self);
-  }
+@protected void sse_encode_call_state(CallState self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+switch (self) { case CallState_Null(): sse_encode_i_32(0, serializer); case CallState_Early(): sse_encode_i_32(1, serializer); case CallState_Incoming(): sse_encode_i_32(2, serializer); case CallState_Calling(): sse_encode_i_32(3, serializer); case CallState_Connecting(): sse_encode_i_32(4, serializer); case CallState_Confirmed(): sse_encode_i_32(5, serializer); case CallState_Disconnected(): sse_encode_i_32(6, serializer); case CallState_Error(field0: final field0): sse_encode_i_32(7, serializer); sse_encode_String(field0, serializer);
+  } }
 
-  @protected
-  void sse_encode_unit(void self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-  }
+@protected void sse_encode_i_32(int self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+serializer.buffer.putInt32(self); }
 
-  @protected
-  void sse_encode_bool(bool self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    serializer.buffer.putUint8(self ? 1 : 0);
-  }
-}
+@protected void sse_encode_i_8(int self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+serializer.buffer.putInt8(self); }
+
+@protected void sse_encode_list_prim_u_8_strict(Uint8List self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+sse_encode_i_32(self.length, serializer);
+                    serializer.buffer.putUint8List(self); }
+
+@protected void sse_encode_log_level(LogLevel self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+sse_encode_i_32(self.index, serializer); }
+
+@protected void sse_encode_on_incomming_call(OnIncommingCall self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+sse_encode_i_32(self.index, serializer); }
+
+@protected void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+switch (self) { case PJSUAError_CreationError(field0: final field0): sse_encode_i_32(0, serializer); sse_encode_String(field0, serializer);
+case PJSUAError_ConfigError(field0: final field0): sse_encode_i_32(1, serializer); sse_encode_String(field0, serializer);
+case PJSUAError_InitializationError(field0: final field0): sse_encode_i_32(2, serializer); sse_encode_String(field0, serializer);
+case PJSUAError_TransportError(field0: final field0): sse_encode_i_32(3, serializer); sse_encode_String(field0, serializer);
+case PJSUAError_DTMFError(field0: final field0): sse_encode_i_32(4, serializer); sse_encode_String(field0, serializer);
+case PJSUAError_CallCreationError(field0: final field0): sse_encode_i_32(5, serializer); sse_encode_String(field0, serializer);
+case PJSUAError_CallStatusUpdateError(field0: final field0): sse_encode_i_32(6, serializer); sse_encode_String(field0, serializer);
+case PJSUAError_AccountCreationError(field0: final field0): sse_encode_i_32(7, serializer); sse_encode_String(field0, serializer);
+case PJSUAError_PJSUAStartError(field0: final field0): sse_encode_i_32(8, serializer); sse_encode_String(field0, serializer);
+case PJSUAError_PJSUADestroyError(field0: final field0): sse_encode_i_32(9, serializer); sse_encode_String(field0, serializer);
+case PJSUAError_InputValueError(field0: final field0): sse_encode_i_32(10, serializer); sse_encode_String(field0, serializer);
+  } }
+
+@protected void sse_encode_u_32(int self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+serializer.buffer.putUint32(self); }
+
+@protected void sse_encode_u_8(int self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+serializer.buffer.putUint8(self); }
+
+@protected void sse_encode_unit(void self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+ }
+
+@protected void sse_encode_bool(bool self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
+serializer.buffer.putUint8(self ? 1 : 0); }
+                }
+                

--- a/lib/rust/frb_generated.io.dart
+++ b/lib/rust/frb_generated.io.dart
@@ -24,9 +24,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AnyhowException dco_decode_AnyhowException(dynamic raw);
 
   @protected
-  RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(
-    dynamic raw,
-  );
+  RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(dynamic raw);
 
   @protected
   RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw);
@@ -74,14 +72,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
 
   @protected
-  RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(
-    SseDeserializer deserializer,
-  );
+  RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(SseDeserializer deserializer);
 
   @protected
-  RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(
-    SseDeserializer deserializer,
-  );
+  RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(SseDeserializer deserializer);
 
   @protected
   String sse_decode_String(SseDeserializer deserializer);
@@ -126,10 +120,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   bool sse_decode_bool(SseDeserializer deserializer);
 
   @protected
-  void sse_encode_AnyhowException(
-    AnyhowException self,
-    SseSerializer serializer,
-  );
+  void sse_encode_AnyhowException(AnyhowException self, SseSerializer serializer);
 
   @protected
   void sse_encode_StreamSink_account_info_Sse(
@@ -138,10 +129,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_StreamSink_call_info_Sse(
-    RustStreamSink<CallInfo> self,
-    SseSerializer serializer,
-  );
+  void sse_encode_StreamSink_call_info_Sse(RustStreamSink<CallInfo> self, SseSerializer serializer);
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);
@@ -162,19 +150,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_i_8(int self, SseSerializer serializer);
 
   @protected
-  void sse_encode_list_prim_u_8_strict(
-    Uint8List self,
-    SseSerializer serializer,
-  );
+  void sse_encode_list_prim_u_8_strict(Uint8List self, SseSerializer serializer);
 
   @protected
   void sse_encode_log_level(LogLevel self, SseSerializer serializer);
 
   @protected
-  void sse_encode_on_incomming_call(
-    OnIncommingCall self,
-    SseSerializer serializer,
-  );
+  void sse_encode_on_incomming_call(OnIncommingCall self, SseSerializer serializer);
 
   @protected
   void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer);
@@ -199,10 +181,8 @@ class RustLibWire implements BaseWire {
       RustLibWire(lib.ffiDynamicLibrary);
 
   /// Holds the symbol lookup function.
-  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-  _lookup;
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  RustLibWire(ffi.DynamicLibrary dynamicLibrary)
-    : _lookup = dynamicLibrary.lookup;
+  RustLibWire(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
 }

--- a/lib/rust/frb_generated.io.dart
+++ b/lib/rust/frb_generated.io.dart
@@ -12,188 +12,138 @@ import 'dart:ffi' as ffi;
 import 'frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_io.dart';
 
-abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
-  RustLibApiImplPlatform({
-    required super.handler,
-    required super.wire,
-    required super.generalizedFrbRustBinding,
-    required super.portManager,
-  });
 
-  @protected
-  AnyhowException dco_decode_AnyhowException(dynamic raw);
 
-  @protected
-  RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(
-    dynamic raw,
-  );
 
-  @protected
-  RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw);
+                abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
+                  RustLibApiImplPlatform({
+                    required super.handler,
+                    required super.wire,
+                    required super.generalizedFrbRustBinding,
+                    required super.portManager,
+                  });
 
-  @protected
-  String dco_decode_String(dynamic raw);
+                  
 
-  @protected
-  AccountInfo dco_decode_account_info(dynamic raw);
+                  @protected AnyhowException dco_decode_AnyhowException(dynamic raw);
 
-  @protected
-  CallInfo dco_decode_call_info(dynamic raw);
+@protected RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(dynamic raw);
 
-  @protected
-  CallState dco_decode_call_state(dynamic raw);
+@protected RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw);
 
-  @protected
-  int dco_decode_i_32(dynamic raw);
+@protected String dco_decode_String(dynamic raw);
 
-  @protected
-  int dco_decode_i_8(dynamic raw);
+@protected AccountInfo dco_decode_account_info(dynamic raw);
 
-  @protected
-  Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+@protected CallInfo dco_decode_call_info(dynamic raw);
 
-  @protected
-  OnIncommingCall dco_decode_on_incomming_call(dynamic raw);
+@protected CallState dco_decode_call_state(dynamic raw);
 
-  @protected
-  PJSUAError dco_decode_pjsua_error(dynamic raw);
+@protected int dco_decode_i_32(dynamic raw);
 
-  @protected
-  int dco_decode_u_32(dynamic raw);
+@protected int dco_decode_i_8(dynamic raw);
 
-  @protected
-  int dco_decode_u_8(dynamic raw);
+@protected Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
-  @protected
-  void dco_decode_unit(dynamic raw);
+@protected LogLevel dco_decode_log_level(dynamic raw);
 
-  @protected
-  AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
+@protected OnIncommingCall dco_decode_on_incomming_call(dynamic raw);
 
-  @protected
-  RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(
-    SseDeserializer deserializer,
-  );
+@protected PJSUAError dco_decode_pjsua_error(dynamic raw);
 
-  @protected
-  RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(
-    SseDeserializer deserializer,
-  );
+@protected int dco_decode_u_32(dynamic raw);
 
-  @protected
-  String sse_decode_String(SseDeserializer deserializer);
+@protected int dco_decode_u_8(dynamic raw);
 
-  @protected
-  AccountInfo sse_decode_account_info(SseDeserializer deserializer);
+@protected void dco_decode_unit(dynamic raw);
 
-  @protected
-  CallInfo sse_decode_call_info(SseDeserializer deserializer);
+@protected AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
 
-  @protected
-  CallState sse_decode_call_state(SseDeserializer deserializer);
+@protected RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(SseDeserializer deserializer);
 
-  @protected
-  int sse_decode_i_32(SseDeserializer deserializer);
+@protected RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(SseDeserializer deserializer);
 
-  @protected
-  int sse_decode_i_8(SseDeserializer deserializer);
+@protected String sse_decode_String(SseDeserializer deserializer);
 
-  @protected
-  Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+@protected AccountInfo sse_decode_account_info(SseDeserializer deserializer);
 
-  @protected
-  OnIncommingCall sse_decode_on_incomming_call(SseDeserializer deserializer);
+@protected CallInfo sse_decode_call_info(SseDeserializer deserializer);
 
-  @protected
-  PJSUAError sse_decode_pjsua_error(SseDeserializer deserializer);
+@protected CallState sse_decode_call_state(SseDeserializer deserializer);
 
-  @protected
-  int sse_decode_u_32(SseDeserializer deserializer);
+@protected int sse_decode_i_32(SseDeserializer deserializer);
 
-  @protected
-  int sse_decode_u_8(SseDeserializer deserializer);
+@protected int sse_decode_i_8(SseDeserializer deserializer);
 
-  @protected
-  void sse_decode_unit(SseDeserializer deserializer);
+@protected Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
-  @protected
-  bool sse_decode_bool(SseDeserializer deserializer);
+@protected LogLevel sse_decode_log_level(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_AnyhowException(
-    AnyhowException self,
-    SseSerializer serializer,
-  );
+@protected OnIncommingCall sse_decode_on_incomming_call(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_StreamSink_account_info_Sse(
-    RustStreamSink<AccountInfo> self,
-    SseSerializer serializer,
-  );
+@protected PJSUAError sse_decode_pjsua_error(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_StreamSink_call_info_Sse(
-    RustStreamSink<CallInfo> self,
-    SseSerializer serializer,
-  );
+@protected int sse_decode_u_32(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_String(String self, SseSerializer serializer);
+@protected int sse_decode_u_8(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_account_info(AccountInfo self, SseSerializer serializer);
+@protected void sse_decode_unit(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_call_info(CallInfo self, SseSerializer serializer);
+@protected bool sse_decode_bool(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_call_state(CallState self, SseSerializer serializer);
+@protected void sse_encode_AnyhowException(AnyhowException self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_i_32(int self, SseSerializer serializer);
+@protected void sse_encode_StreamSink_account_info_Sse(RustStreamSink<AccountInfo> self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_i_8(int self, SseSerializer serializer);
+@protected void sse_encode_StreamSink_call_info_Sse(RustStreamSink<CallInfo> self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_list_prim_u_8_strict(
-    Uint8List self,
-    SseSerializer serializer,
-  );
+@protected void sse_encode_String(String self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_on_incomming_call(
-    OnIncommingCall self,
-    SseSerializer serializer,
-  );
+@protected void sse_encode_account_info(AccountInfo self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer);
+@protected void sse_encode_call_info(CallInfo self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_u_32(int self, SseSerializer serializer);
+@protected void sse_encode_call_state(CallState self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_u_8(int self, SseSerializer serializer);
+@protected void sse_encode_i_32(int self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_unit(void self, SseSerializer serializer);
+@protected void sse_encode_i_8(int self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_bool(bool self, SseSerializer serializer);
-}
+@protected void sse_encode_list_prim_u_8_strict(Uint8List self, SseSerializer serializer);
+
+@protected void sse_encode_log_level(LogLevel self, SseSerializer serializer);
+
+@protected void sse_encode_on_incomming_call(OnIncommingCall self, SseSerializer serializer);
+
+@protected void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer);
+
+@protected void sse_encode_u_32(int self, SseSerializer serializer);
+
+@protected void sse_encode_u_8(int self, SseSerializer serializer);
+
+@protected void sse_encode_unit(void self, SseSerializer serializer);
+
+@protected void sse_encode_bool(bool self, SseSerializer serializer);
+                }
+                
+
 
 // Section: wire_class
 
-class RustLibWire implements BaseWire {
-  factory RustLibWire.fromExternalLibrary(ExternalLibrary lib) =>
-      RustLibWire(lib.ffiDynamicLibrary);
 
-  /// Holds the symbol lookup function.
-  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-  _lookup;
+        class RustLibWire implements BaseWire {
 
-  /// The symbols are looked up in [dynamicLibrary].
-  RustLibWire(ffi.DynamicLibrary dynamicLibrary)
-    : _lookup = dynamicLibrary.lookup;
-}
+            factory RustLibWire.fromExternalLibrary(ExternalLibrary lib) =>
+              RustLibWire(lib.ffiDynamicLibrary);
+        
+            /// Holds the symbol lookup function.
+            final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+                _lookup;
+  
+            /// The symbols are looked up in [dynamicLibrary].
+            RustLibWire(ffi.DynamicLibrary dynamicLibrary)
+                : _lookup = dynamicLibrary.lookup;
+
+            
+        }
+        

--- a/lib/rust/frb_generated.io.dart
+++ b/lib/rust/frb_generated.io.dart
@@ -12,138 +12,197 @@ import 'dart:ffi' as ffi;
 import 'frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_io.dart';
 
+abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
+  RustLibApiImplPlatform({
+    required super.handler,
+    required super.wire,
+    required super.generalizedFrbRustBinding,
+    required super.portManager,
+  });
 
+  @protected
+  AnyhowException dco_decode_AnyhowException(dynamic raw);
 
+  @protected
+  RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(
+    dynamic raw,
+  );
 
-                abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
-                  RustLibApiImplPlatform({
-                    required super.handler,
-                    required super.wire,
-                    required super.generalizedFrbRustBinding,
-                    required super.portManager,
-                  });
+  @protected
+  RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw);
 
-                  
+  @protected
+  String dco_decode_String(dynamic raw);
 
-                  @protected AnyhowException dco_decode_AnyhowException(dynamic raw);
+  @protected
+  AccountInfo dco_decode_account_info(dynamic raw);
 
-@protected RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(dynamic raw);
+  @protected
+  CallInfo dco_decode_call_info(dynamic raw);
 
-@protected RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw);
+  @protected
+  CallState dco_decode_call_state(dynamic raw);
 
-@protected String dco_decode_String(dynamic raw);
+  @protected
+  int dco_decode_i_32(dynamic raw);
 
-@protected AccountInfo dco_decode_account_info(dynamic raw);
+  @protected
+  int dco_decode_i_8(dynamic raw);
 
-@protected CallInfo dco_decode_call_info(dynamic raw);
+  @protected
+  Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
-@protected CallState dco_decode_call_state(dynamic raw);
+  @protected
+  LogLevel dco_decode_log_level(dynamic raw);
 
-@protected int dco_decode_i_32(dynamic raw);
+  @protected
+  OnIncommingCall dco_decode_on_incomming_call(dynamic raw);
 
-@protected int dco_decode_i_8(dynamic raw);
+  @protected
+  PJSUAError dco_decode_pjsua_error(dynamic raw);
 
-@protected Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+  @protected
+  int dco_decode_u_32(dynamic raw);
 
-@protected LogLevel dco_decode_log_level(dynamic raw);
+  @protected
+  int dco_decode_u_8(dynamic raw);
 
-@protected OnIncommingCall dco_decode_on_incomming_call(dynamic raw);
+  @protected
+  void dco_decode_unit(dynamic raw);
 
-@protected PJSUAError dco_decode_pjsua_error(dynamic raw);
+  @protected
+  AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
 
-@protected int dco_decode_u_32(dynamic raw);
+  @protected
+  RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(
+    SseDeserializer deserializer,
+  );
 
-@protected int dco_decode_u_8(dynamic raw);
+  @protected
+  RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(
+    SseDeserializer deserializer,
+  );
 
-@protected void dco_decode_unit(dynamic raw);
+  @protected
+  String sse_decode_String(SseDeserializer deserializer);
 
-@protected AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
+  @protected
+  AccountInfo sse_decode_account_info(SseDeserializer deserializer);
 
-@protected RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(SseDeserializer deserializer);
+  @protected
+  CallInfo sse_decode_call_info(SseDeserializer deserializer);
 
-@protected RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(SseDeserializer deserializer);
+  @protected
+  CallState sse_decode_call_state(SseDeserializer deserializer);
 
-@protected String sse_decode_String(SseDeserializer deserializer);
+  @protected
+  int sse_decode_i_32(SseDeserializer deserializer);
 
-@protected AccountInfo sse_decode_account_info(SseDeserializer deserializer);
+  @protected
+  int sse_decode_i_8(SseDeserializer deserializer);
 
-@protected CallInfo sse_decode_call_info(SseDeserializer deserializer);
+  @protected
+  Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
-@protected CallState sse_decode_call_state(SseDeserializer deserializer);
+  @protected
+  LogLevel sse_decode_log_level(SseDeserializer deserializer);
 
-@protected int sse_decode_i_32(SseDeserializer deserializer);
+  @protected
+  OnIncommingCall sse_decode_on_incomming_call(SseDeserializer deserializer);
 
-@protected int sse_decode_i_8(SseDeserializer deserializer);
+  @protected
+  PJSUAError sse_decode_pjsua_error(SseDeserializer deserializer);
 
-@protected Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+  @protected
+  int sse_decode_u_32(SseDeserializer deserializer);
 
-@protected LogLevel sse_decode_log_level(SseDeserializer deserializer);
+  @protected
+  int sse_decode_u_8(SseDeserializer deserializer);
 
-@protected OnIncommingCall sse_decode_on_incomming_call(SseDeserializer deserializer);
+  @protected
+  void sse_decode_unit(SseDeserializer deserializer);
 
-@protected PJSUAError sse_decode_pjsua_error(SseDeserializer deserializer);
+  @protected
+  bool sse_decode_bool(SseDeserializer deserializer);
 
-@protected int sse_decode_u_32(SseDeserializer deserializer);
+  @protected
+  void sse_encode_AnyhowException(
+    AnyhowException self,
+    SseSerializer serializer,
+  );
 
-@protected int sse_decode_u_8(SseDeserializer deserializer);
+  @protected
+  void sse_encode_StreamSink_account_info_Sse(
+    RustStreamSink<AccountInfo> self,
+    SseSerializer serializer,
+  );
 
-@protected void sse_decode_unit(SseDeserializer deserializer);
+  @protected
+  void sse_encode_StreamSink_call_info_Sse(
+    RustStreamSink<CallInfo> self,
+    SseSerializer serializer,
+  );
 
-@protected bool sse_decode_bool(SseDeserializer deserializer);
+  @protected
+  void sse_encode_String(String self, SseSerializer serializer);
 
-@protected void sse_encode_AnyhowException(AnyhowException self, SseSerializer serializer);
+  @protected
+  void sse_encode_account_info(AccountInfo self, SseSerializer serializer);
 
-@protected void sse_encode_StreamSink_account_info_Sse(RustStreamSink<AccountInfo> self, SseSerializer serializer);
+  @protected
+  void sse_encode_call_info(CallInfo self, SseSerializer serializer);
 
-@protected void sse_encode_StreamSink_call_info_Sse(RustStreamSink<CallInfo> self, SseSerializer serializer);
+  @protected
+  void sse_encode_call_state(CallState self, SseSerializer serializer);
 
-@protected void sse_encode_String(String self, SseSerializer serializer);
+  @protected
+  void sse_encode_i_32(int self, SseSerializer serializer);
 
-@protected void sse_encode_account_info(AccountInfo self, SseSerializer serializer);
+  @protected
+  void sse_encode_i_8(int self, SseSerializer serializer);
 
-@protected void sse_encode_call_info(CallInfo self, SseSerializer serializer);
+  @protected
+  void sse_encode_list_prim_u_8_strict(
+    Uint8List self,
+    SseSerializer serializer,
+  );
 
-@protected void sse_encode_call_state(CallState self, SseSerializer serializer);
+  @protected
+  void sse_encode_log_level(LogLevel self, SseSerializer serializer);
 
-@protected void sse_encode_i_32(int self, SseSerializer serializer);
+  @protected
+  void sse_encode_on_incomming_call(
+    OnIncommingCall self,
+    SseSerializer serializer,
+  );
 
-@protected void sse_encode_i_8(int self, SseSerializer serializer);
+  @protected
+  void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer);
 
-@protected void sse_encode_list_prim_u_8_strict(Uint8List self, SseSerializer serializer);
+  @protected
+  void sse_encode_u_32(int self, SseSerializer serializer);
 
-@protected void sse_encode_log_level(LogLevel self, SseSerializer serializer);
+  @protected
+  void sse_encode_u_8(int self, SseSerializer serializer);
 
-@protected void sse_encode_on_incomming_call(OnIncommingCall self, SseSerializer serializer);
+  @protected
+  void sse_encode_unit(void self, SseSerializer serializer);
 
-@protected void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer);
-
-@protected void sse_encode_u_32(int self, SseSerializer serializer);
-
-@protected void sse_encode_u_8(int self, SseSerializer serializer);
-
-@protected void sse_encode_unit(void self, SseSerializer serializer);
-
-@protected void sse_encode_bool(bool self, SseSerializer serializer);
-                }
-                
-
+  @protected
+  void sse_encode_bool(bool self, SseSerializer serializer);
+}
 
 // Section: wire_class
 
+class RustLibWire implements BaseWire {
+  factory RustLibWire.fromExternalLibrary(ExternalLibrary lib) =>
+      RustLibWire(lib.ffiDynamicLibrary);
 
-        class RustLibWire implements BaseWire {
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+  _lookup;
 
-            factory RustLibWire.fromExternalLibrary(ExternalLibrary lib) =>
-              RustLibWire(lib.ffiDynamicLibrary);
-        
-            /// Holds the symbol lookup function.
-            final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-                _lookup;
-  
-            /// The symbols are looked up in [dynamicLibrary].
-            RustLibWire(ffi.DynamicLibrary dynamicLibrary)
-                : _lookup = dynamicLibrary.lookup;
-
-            
-        }
-        
+  /// The symbols are looked up in [dynamicLibrary].
+  RustLibWire(ffi.DynamicLibrary dynamicLibrary)
+    : _lookup = dynamicLibrary.lookup;
+}

--- a/lib/rust/frb_generated.web.dart
+++ b/lib/rust/frb_generated.web.dart
@@ -3,6 +3,7 @@
 
 // ignore_for_file: unused_import, unused_element, unnecessary_import, duplicate_ignore, invalid_use_of_internal_member, annotate_overrides, non_constant_identifier_names, curly_braces_in_flow_control_structures, prefer_const_literals_to_create_immutables, unused_field
 
+
 // Static analysis wrongly picks the IO variant, thus ignore this
 // ignore_for_file: argument_type_not_assignable
 
@@ -14,186 +15,132 @@ import 'dart:convert';
 import 'frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_web.dart';
 
-abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
-  RustLibApiImplPlatform({
-    required super.handler,
-    required super.wire,
-    required super.generalizedFrbRustBinding,
-    required super.portManager,
-  });
 
-  @protected
-  AnyhowException dco_decode_AnyhowException(dynamic raw);
 
-  @protected
-  RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(
-    dynamic raw,
-  );
 
-  @protected
-  RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw);
+                abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
+                  RustLibApiImplPlatform({
+                    required super.handler,
+                    required super.wire,
+                    required super.generalizedFrbRustBinding,
+                    required super.portManager,
+                  });
 
-  @protected
-  String dco_decode_String(dynamic raw);
+                  
 
-  @protected
-  AccountInfo dco_decode_account_info(dynamic raw);
+                  @protected AnyhowException dco_decode_AnyhowException(dynamic raw);
 
-  @protected
-  CallInfo dco_decode_call_info(dynamic raw);
+@protected RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(dynamic raw);
 
-  @protected
-  CallState dco_decode_call_state(dynamic raw);
+@protected RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw);
 
-  @protected
-  int dco_decode_i_32(dynamic raw);
+@protected String dco_decode_String(dynamic raw);
 
-  @protected
-  int dco_decode_i_8(dynamic raw);
+@protected AccountInfo dco_decode_account_info(dynamic raw);
 
-  @protected
-  Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+@protected CallInfo dco_decode_call_info(dynamic raw);
 
-  @protected
-  OnIncommingCall dco_decode_on_incomming_call(dynamic raw);
+@protected CallState dco_decode_call_state(dynamic raw);
 
-  @protected
-  PJSUAError dco_decode_pjsua_error(dynamic raw);
+@protected int dco_decode_i_32(dynamic raw);
 
-  @protected
-  int dco_decode_u_32(dynamic raw);
+@protected int dco_decode_i_8(dynamic raw);
 
-  @protected
-  int dco_decode_u_8(dynamic raw);
+@protected Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
-  @protected
-  void dco_decode_unit(dynamic raw);
+@protected LogLevel dco_decode_log_level(dynamic raw);
 
-  @protected
-  AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
+@protected OnIncommingCall dco_decode_on_incomming_call(dynamic raw);
 
-  @protected
-  RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(
-    SseDeserializer deserializer,
-  );
+@protected PJSUAError dco_decode_pjsua_error(dynamic raw);
 
-  @protected
-  RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(
-    SseDeserializer deserializer,
-  );
+@protected int dco_decode_u_32(dynamic raw);
 
-  @protected
-  String sse_decode_String(SseDeserializer deserializer);
+@protected int dco_decode_u_8(dynamic raw);
 
-  @protected
-  AccountInfo sse_decode_account_info(SseDeserializer deserializer);
+@protected void dco_decode_unit(dynamic raw);
 
-  @protected
-  CallInfo sse_decode_call_info(SseDeserializer deserializer);
+@protected AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
 
-  @protected
-  CallState sse_decode_call_state(SseDeserializer deserializer);
+@protected RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(SseDeserializer deserializer);
 
-  @protected
-  int sse_decode_i_32(SseDeserializer deserializer);
+@protected RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(SseDeserializer deserializer);
 
-  @protected
-  int sse_decode_i_8(SseDeserializer deserializer);
+@protected String sse_decode_String(SseDeserializer deserializer);
 
-  @protected
-  Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+@protected AccountInfo sse_decode_account_info(SseDeserializer deserializer);
 
-  @protected
-  OnIncommingCall sse_decode_on_incomming_call(SseDeserializer deserializer);
+@protected CallInfo sse_decode_call_info(SseDeserializer deserializer);
 
-  @protected
-  PJSUAError sse_decode_pjsua_error(SseDeserializer deserializer);
+@protected CallState sse_decode_call_state(SseDeserializer deserializer);
 
-  @protected
-  int sse_decode_u_32(SseDeserializer deserializer);
+@protected int sse_decode_i_32(SseDeserializer deserializer);
 
-  @protected
-  int sse_decode_u_8(SseDeserializer deserializer);
+@protected int sse_decode_i_8(SseDeserializer deserializer);
 
-  @protected
-  void sse_decode_unit(SseDeserializer deserializer);
+@protected Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
-  @protected
-  bool sse_decode_bool(SseDeserializer deserializer);
+@protected LogLevel sse_decode_log_level(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_AnyhowException(
-    AnyhowException self,
-    SseSerializer serializer,
-  );
+@protected OnIncommingCall sse_decode_on_incomming_call(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_StreamSink_account_info_Sse(
-    RustStreamSink<AccountInfo> self,
-    SseSerializer serializer,
-  );
+@protected PJSUAError sse_decode_pjsua_error(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_StreamSink_call_info_Sse(
-    RustStreamSink<CallInfo> self,
-    SseSerializer serializer,
-  );
+@protected int sse_decode_u_32(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_String(String self, SseSerializer serializer);
+@protected int sse_decode_u_8(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_account_info(AccountInfo self, SseSerializer serializer);
+@protected void sse_decode_unit(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_call_info(CallInfo self, SseSerializer serializer);
+@protected bool sse_decode_bool(SseDeserializer deserializer);
 
-  @protected
-  void sse_encode_call_state(CallState self, SseSerializer serializer);
+@protected void sse_encode_AnyhowException(AnyhowException self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_i_32(int self, SseSerializer serializer);
+@protected void sse_encode_StreamSink_account_info_Sse(RustStreamSink<AccountInfo> self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_i_8(int self, SseSerializer serializer);
+@protected void sse_encode_StreamSink_call_info_Sse(RustStreamSink<CallInfo> self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_list_prim_u_8_strict(
-    Uint8List self,
-    SseSerializer serializer,
-  );
+@protected void sse_encode_String(String self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_on_incomming_call(
-    OnIncommingCall self,
-    SseSerializer serializer,
-  );
+@protected void sse_encode_account_info(AccountInfo self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer);
+@protected void sse_encode_call_info(CallInfo self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_u_32(int self, SseSerializer serializer);
+@protected void sse_encode_call_state(CallState self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_u_8(int self, SseSerializer serializer);
+@protected void sse_encode_i_32(int self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_unit(void self, SseSerializer serializer);
+@protected void sse_encode_i_8(int self, SseSerializer serializer);
 
-  @protected
-  void sse_encode_bool(bool self, SseSerializer serializer);
-}
+@protected void sse_encode_list_prim_u_8_strict(Uint8List self, SseSerializer serializer);
+
+@protected void sse_encode_log_level(LogLevel self, SseSerializer serializer);
+
+@protected void sse_encode_on_incomming_call(OnIncommingCall self, SseSerializer serializer);
+
+@protected void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer);
+
+@protected void sse_encode_u_32(int self, SseSerializer serializer);
+
+@protected void sse_encode_u_8(int self, SseSerializer serializer);
+
+@protected void sse_encode_unit(void self, SseSerializer serializer);
+
+@protected void sse_encode_bool(bool self, SseSerializer serializer);
+                }
+                
+
 
 // Section: wire_class
 
 class RustLibWire implements BaseWire {
-  RustLibWire.fromExternalLibrary(ExternalLibrary lib);
-}
+            RustLibWire.fromExternalLibrary(ExternalLibrary lib);
 
-@JS('wasm_bindgen')
-external RustLibWasmModule get wasmModule;
+            
+        }
+        @JS('wasm_bindgen') external RustLibWasmModule get wasmModule;
 
-@JS()
-@anonymous
-extension type RustLibWasmModule._(JSObject _) implements JSObject {}
+        @JS() @anonymous extension type RustLibWasmModule._(JSObject _) implements JSObject {
+            
+        }
+        

--- a/lib/rust/frb_generated.web.dart
+++ b/lib/rust/frb_generated.web.dart
@@ -26,9 +26,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AnyhowException dco_decode_AnyhowException(dynamic raw);
 
   @protected
-  RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(
-    dynamic raw,
-  );
+  RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(dynamic raw);
 
   @protected
   RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw);
@@ -76,14 +74,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
 
   @protected
-  RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(
-    SseDeserializer deserializer,
-  );
+  RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(SseDeserializer deserializer);
 
   @protected
-  RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(
-    SseDeserializer deserializer,
-  );
+  RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(SseDeserializer deserializer);
 
   @protected
   String sse_decode_String(SseDeserializer deserializer);
@@ -128,10 +122,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   bool sse_decode_bool(SseDeserializer deserializer);
 
   @protected
-  void sse_encode_AnyhowException(
-    AnyhowException self,
-    SseSerializer serializer,
-  );
+  void sse_encode_AnyhowException(AnyhowException self, SseSerializer serializer);
 
   @protected
   void sse_encode_StreamSink_account_info_Sse(
@@ -140,10 +131,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_StreamSink_call_info_Sse(
-    RustStreamSink<CallInfo> self,
-    SseSerializer serializer,
-  );
+  void sse_encode_StreamSink_call_info_Sse(RustStreamSink<CallInfo> self, SseSerializer serializer);
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);
@@ -164,19 +152,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_i_8(int self, SseSerializer serializer);
 
   @protected
-  void sse_encode_list_prim_u_8_strict(
-    Uint8List self,
-    SseSerializer serializer,
-  );
+  void sse_encode_list_prim_u_8_strict(Uint8List self, SseSerializer serializer);
 
   @protected
   void sse_encode_log_level(LogLevel self, SseSerializer serializer);
 
   @protected
-  void sse_encode_on_incomming_call(
-    OnIncommingCall self,
-    SseSerializer serializer,
-  );
+  void sse_encode_on_incomming_call(OnIncommingCall self, SseSerializer serializer);
 
   @protected
   void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer);

--- a/lib/rust/frb_generated.web.dart
+++ b/lib/rust/frb_generated.web.dart
@@ -3,7 +3,6 @@
 
 // ignore_for_file: unused_import, unused_element, unnecessary_import, duplicate_ignore, invalid_use_of_internal_member, annotate_overrides, non_constant_identifier_names, curly_braces_in_flow_control_structures, prefer_const_literals_to_create_immutables, unused_field
 
-
 // Static analysis wrongly picks the IO variant, thus ignore this
 // ignore_for_file: argument_type_not_assignable
 
@@ -15,132 +14,195 @@ import 'dart:convert';
 import 'frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_web.dart';
 
+abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
+  RustLibApiImplPlatform({
+    required super.handler,
+    required super.wire,
+    required super.generalizedFrbRustBinding,
+    required super.portManager,
+  });
 
+  @protected
+  AnyhowException dco_decode_AnyhowException(dynamic raw);
 
+  @protected
+  RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(
+    dynamic raw,
+  );
 
-                abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
-                  RustLibApiImplPlatform({
-                    required super.handler,
-                    required super.wire,
-                    required super.generalizedFrbRustBinding,
-                    required super.portManager,
-                  });
+  @protected
+  RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw);
 
-                  
+  @protected
+  String dco_decode_String(dynamic raw);
 
-                  @protected AnyhowException dco_decode_AnyhowException(dynamic raw);
+  @protected
+  AccountInfo dco_decode_account_info(dynamic raw);
 
-@protected RustStreamSink<AccountInfo> dco_decode_StreamSink_account_info_Sse(dynamic raw);
+  @protected
+  CallInfo dco_decode_call_info(dynamic raw);
 
-@protected RustStreamSink<CallInfo> dco_decode_StreamSink_call_info_Sse(dynamic raw);
+  @protected
+  CallState dco_decode_call_state(dynamic raw);
 
-@protected String dco_decode_String(dynamic raw);
+  @protected
+  int dco_decode_i_32(dynamic raw);
 
-@protected AccountInfo dco_decode_account_info(dynamic raw);
+  @protected
+  int dco_decode_i_8(dynamic raw);
 
-@protected CallInfo dco_decode_call_info(dynamic raw);
+  @protected
+  Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
-@protected CallState dco_decode_call_state(dynamic raw);
+  @protected
+  LogLevel dco_decode_log_level(dynamic raw);
 
-@protected int dco_decode_i_32(dynamic raw);
+  @protected
+  OnIncommingCall dco_decode_on_incomming_call(dynamic raw);
 
-@protected int dco_decode_i_8(dynamic raw);
+  @protected
+  PJSUAError dco_decode_pjsua_error(dynamic raw);
 
-@protected Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+  @protected
+  int dco_decode_u_32(dynamic raw);
 
-@protected LogLevel dco_decode_log_level(dynamic raw);
+  @protected
+  int dco_decode_u_8(dynamic raw);
 
-@protected OnIncommingCall dco_decode_on_incomming_call(dynamic raw);
+  @protected
+  void dco_decode_unit(dynamic raw);
 
-@protected PJSUAError dco_decode_pjsua_error(dynamic raw);
+  @protected
+  AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
 
-@protected int dco_decode_u_32(dynamic raw);
+  @protected
+  RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(
+    SseDeserializer deserializer,
+  );
 
-@protected int dco_decode_u_8(dynamic raw);
+  @protected
+  RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(
+    SseDeserializer deserializer,
+  );
 
-@protected void dco_decode_unit(dynamic raw);
+  @protected
+  String sse_decode_String(SseDeserializer deserializer);
 
-@protected AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
+  @protected
+  AccountInfo sse_decode_account_info(SseDeserializer deserializer);
 
-@protected RustStreamSink<AccountInfo> sse_decode_StreamSink_account_info_Sse(SseDeserializer deserializer);
+  @protected
+  CallInfo sse_decode_call_info(SseDeserializer deserializer);
 
-@protected RustStreamSink<CallInfo> sse_decode_StreamSink_call_info_Sse(SseDeserializer deserializer);
+  @protected
+  CallState sse_decode_call_state(SseDeserializer deserializer);
 
-@protected String sse_decode_String(SseDeserializer deserializer);
+  @protected
+  int sse_decode_i_32(SseDeserializer deserializer);
 
-@protected AccountInfo sse_decode_account_info(SseDeserializer deserializer);
+  @protected
+  int sse_decode_i_8(SseDeserializer deserializer);
 
-@protected CallInfo sse_decode_call_info(SseDeserializer deserializer);
+  @protected
+  Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
-@protected CallState sse_decode_call_state(SseDeserializer deserializer);
+  @protected
+  LogLevel sse_decode_log_level(SseDeserializer deserializer);
 
-@protected int sse_decode_i_32(SseDeserializer deserializer);
+  @protected
+  OnIncommingCall sse_decode_on_incomming_call(SseDeserializer deserializer);
 
-@protected int sse_decode_i_8(SseDeserializer deserializer);
+  @protected
+  PJSUAError sse_decode_pjsua_error(SseDeserializer deserializer);
 
-@protected Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+  @protected
+  int sse_decode_u_32(SseDeserializer deserializer);
 
-@protected LogLevel sse_decode_log_level(SseDeserializer deserializer);
+  @protected
+  int sse_decode_u_8(SseDeserializer deserializer);
 
-@protected OnIncommingCall sse_decode_on_incomming_call(SseDeserializer deserializer);
+  @protected
+  void sse_decode_unit(SseDeserializer deserializer);
 
-@protected PJSUAError sse_decode_pjsua_error(SseDeserializer deserializer);
+  @protected
+  bool sse_decode_bool(SseDeserializer deserializer);
 
-@protected int sse_decode_u_32(SseDeserializer deserializer);
+  @protected
+  void sse_encode_AnyhowException(
+    AnyhowException self,
+    SseSerializer serializer,
+  );
 
-@protected int sse_decode_u_8(SseDeserializer deserializer);
+  @protected
+  void sse_encode_StreamSink_account_info_Sse(
+    RustStreamSink<AccountInfo> self,
+    SseSerializer serializer,
+  );
 
-@protected void sse_decode_unit(SseDeserializer deserializer);
+  @protected
+  void sse_encode_StreamSink_call_info_Sse(
+    RustStreamSink<CallInfo> self,
+    SseSerializer serializer,
+  );
 
-@protected bool sse_decode_bool(SseDeserializer deserializer);
+  @protected
+  void sse_encode_String(String self, SseSerializer serializer);
 
-@protected void sse_encode_AnyhowException(AnyhowException self, SseSerializer serializer);
+  @protected
+  void sse_encode_account_info(AccountInfo self, SseSerializer serializer);
 
-@protected void sse_encode_StreamSink_account_info_Sse(RustStreamSink<AccountInfo> self, SseSerializer serializer);
+  @protected
+  void sse_encode_call_info(CallInfo self, SseSerializer serializer);
 
-@protected void sse_encode_StreamSink_call_info_Sse(RustStreamSink<CallInfo> self, SseSerializer serializer);
+  @protected
+  void sse_encode_call_state(CallState self, SseSerializer serializer);
 
-@protected void sse_encode_String(String self, SseSerializer serializer);
+  @protected
+  void sse_encode_i_32(int self, SseSerializer serializer);
 
-@protected void sse_encode_account_info(AccountInfo self, SseSerializer serializer);
+  @protected
+  void sse_encode_i_8(int self, SseSerializer serializer);
 
-@protected void sse_encode_call_info(CallInfo self, SseSerializer serializer);
+  @protected
+  void sse_encode_list_prim_u_8_strict(
+    Uint8List self,
+    SseSerializer serializer,
+  );
 
-@protected void sse_encode_call_state(CallState self, SseSerializer serializer);
+  @protected
+  void sse_encode_log_level(LogLevel self, SseSerializer serializer);
 
-@protected void sse_encode_i_32(int self, SseSerializer serializer);
+  @protected
+  void sse_encode_on_incomming_call(
+    OnIncommingCall self,
+    SseSerializer serializer,
+  );
 
-@protected void sse_encode_i_8(int self, SseSerializer serializer);
+  @protected
+  void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer);
 
-@protected void sse_encode_list_prim_u_8_strict(Uint8List self, SseSerializer serializer);
+  @protected
+  void sse_encode_u_32(int self, SseSerializer serializer);
 
-@protected void sse_encode_log_level(LogLevel self, SseSerializer serializer);
+  @protected
+  void sse_encode_u_8(int self, SseSerializer serializer);
 
-@protected void sse_encode_on_incomming_call(OnIncommingCall self, SseSerializer serializer);
+  @protected
+  void sse_encode_unit(void self, SseSerializer serializer);
 
-@protected void sse_encode_pjsua_error(PJSUAError self, SseSerializer serializer);
-
-@protected void sse_encode_u_32(int self, SseSerializer serializer);
-
-@protected void sse_encode_u_8(int self, SseSerializer serializer);
-
-@protected void sse_encode_unit(void self, SseSerializer serializer);
-
-@protected void sse_encode_bool(bool self, SseSerializer serializer);
-                }
-                
-
+  @protected
+  void sse_encode_bool(bool self, SseSerializer serializer);
+}
 
 // Section: wire_class
 
 class RustLibWire implements BaseWire {
-            RustLibWire.fromExternalLibrary(ExternalLibrary lib);
+  RustLibWire.fromExternalLibrary(ExternalLibrary lib);
+}
 
-            
-        }
-        @JS('wasm_bindgen') external RustLibWasmModule get wasmModule;
+@JS('wasm_bindgen')
+external RustLibWasmModule get wasmModule;
 
-        @JS() @anonymous extension type RustLibWasmModule._(JSObject _) implements JSObject {
-            
-        }
-        
+@JS()
+@anonymous
+extension type RustLibWasmModule._(JSObject _) implements JSObject {}

--- a/lib/rust_lib.dart
+++ b/lib/rust_lib.dart
@@ -1,0 +1,3 @@
+export 'rust/frb_generated.dart'
+    if (dart.library.js_interop) 'src/rust_lib_web.dart'
+    show RustLib;

--- a/lib/rust_lib.dart
+++ b/lib/rust_lib.dart
@@ -1,3 +1,1 @@
-export 'rust/frb_generated.dart'
-    if (dart.library.js_interop) 'src/rust_lib_web.dart'
-    show RustLib;
+export 'rust/frb_generated.dart' if (dart.library.js_interop) 'src/rust_lib_web.dart' show RustLib;

--- a/lib/sip_api.dart
+++ b/lib/sip_api.dart
@@ -1,0 +1,8 @@
+import 'src/sip_api_interface.dart';
+import 'src/sip_api_native.dart'
+    if (dart.library.js_interop) 'src/sip_api_web.dart'
+    as platform;
+
+export 'src/sip_api_interface.dart';
+
+final SipApi sipApi = platform.createSipApi();

--- a/lib/sip_api.dart
+++ b/lib/sip_api.dart
@@ -1,7 +1,5 @@
 import 'src/sip_api_interface.dart';
-import 'src/sip_api_native.dart'
-    if (dart.library.js_interop) 'src/sip_api_web.dart'
-    as platform;
+import 'src/sip_api_native.dart' if (dart.library.js_interop) 'src/sip_api_web.dart' as platform;
 
 export 'src/sip_api_interface.dart';
 

--- a/lib/sip_service.dart
+++ b/lib/sip_service.dart
@@ -112,11 +112,7 @@ class SIPService {
       if (initialized == false) {
         throw 'SIPService not initialized';
       }
-      final accId = await accountSetup(
-        uri: uri,
-        username: username,
-        password: password,
-      );
+      final accId = await accountSetup(uri: uri, username: username, password: password);
       // save account ID so we check for its registration updates in account stream
       accountID = accId;
       debugPrint('Account registered with ID: $accId');

--- a/lib/sip_service.dart
+++ b/lib/sip_service.dart
@@ -4,7 +4,6 @@ import 'package:flutter_rust_sip/flutter_rust_sip.dart' as frs;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_rust_sip/flutter_rust_sip.dart';
-import 'package:flutter_rust_sip/rust/api/simple.dart';
 import 'package:rxdart/subjects.dart' as rx;
 
 class SIPService {

--- a/lib/sip_service.dart
+++ b/lib/sip_service.dart
@@ -95,7 +95,7 @@ class SIPService {
       return Future.error(initializeErr.toString());
     }
   }
- 
+
   Future<void> dispose() async {
     initialized = false;
     await callStateBroadcast.close();
@@ -136,10 +136,7 @@ class SIPService {
       error = 'SIPService not initialized';
     }
     try {
-      final callId = await makeCall(
-        phoneNumber: phoneNumber,
-        domain: domain,
-      );
+      final callId = await makeCall(phoneNumber: phoneNumber, domain: domain);
       debugPrint('Call initiated to $phoneNumber with call ID: $callId');
 
       return callId;

--- a/lib/src/rust_lib_web.dart
+++ b/lib/src/rust_lib_web.dart
@@ -1,0 +1,16 @@
+import '../rust/frb_generated.dart' show RustLibApi;
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    show BaseHandler, ExternalLibrary;
+
+abstract final class RustLib {
+  static Future<void> init({
+    RustLibApi? api,
+    BaseHandler? handler,
+    ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
+  }) async {}
+
+  static void initMock({required RustLibApi api}) {}
+
+  static void dispose() {}
+}

--- a/lib/src/sip_api_interface.dart
+++ b/lib/src/sip_api_interface.dart
@@ -1,0 +1,32 @@
+import '../rust/core/dart_types.dart';
+import '../rust/core/types.dart';
+
+abstract interface class SipApi {
+  Future<void> initialize();
+
+  void dispose();
+
+  Future<int> initPjsua({
+    required int localPort,
+    required OnIncommingCall incomingCallStrategy,
+    required String stunSrv,
+  });
+
+  Future<int> accountSetup({
+    required String uri,
+    required String username,
+    required String password,
+  });
+
+  Stream<CallInfo> registerCallStream();
+
+  Stream<AccountInfo> registerAccountStream();
+
+  Future<void> markCallAlive({required int callId});
+
+  Future<int> makeCall({required String phoneNumber, required String domain});
+
+  Future<void> hangupCall({required int callId});
+
+  Future<int> destroyPjsua();
+}

--- a/lib/src/sip_api_native.dart
+++ b/lib/src/sip_api_native.dart
@@ -49,11 +49,7 @@ class NativeSipApi implements SipApi {
     required String password,
   }) async {
     await initialize();
-    return rust_api.accountSetup(
-      uri: uri,
-      username: username,
-      password: password,
-    );
+    return rust_api.accountSetup(uri: uri, username: username, password: password);
   }
 
   @override
@@ -75,10 +71,7 @@ class NativeSipApi implements SipApi {
   }
 
   @override
-  Future<int> makeCall({
-    required String phoneNumber,
-    required String domain,
-  }) async {
+  Future<int> makeCall({required String phoneNumber, required String domain}) async {
     await initialize();
     return rust_api.makeCall(phoneNumber: phoneNumber, domain: domain);
   }

--- a/lib/src/sip_api_native.dart
+++ b/lib/src/sip_api_native.dart
@@ -1,0 +1,95 @@
+import '../rust/api/simple.dart' as rust_api;
+import '../rust/core/dart_types.dart';
+import '../rust/core/types.dart';
+import '../rust/frb_generated.dart' as bridge;
+import 'sip_api_interface.dart';
+
+SipApi createSipApi() => NativeSipApi();
+
+class NativeSipApi implements SipApi {
+  Future<void>? _initialization;
+
+  @override
+  Future<void> initialize() {
+    if (bridge.RustLib.instance.initialized) {
+      return Future.value();
+    }
+
+    return _initialization ??= bridge.RustLib.init();
+  }
+
+  @override
+  void dispose() {
+    if (bridge.RustLib.instance.initialized) {
+      bridge.RustLib.dispose();
+      _initialization = null;
+    }
+  }
+
+  @override
+  Future<int> initPjsua({
+    required int localPort,
+    required OnIncommingCall incomingCallStrategy,
+    required String stunSrv,
+  }) async {
+    await initialize();
+    return rust_api.initPjsua(
+      localPort: localPort,
+      incomingCallStrategy: incomingCallStrategy,
+      stunSrv: stunSrv,
+    );
+  }
+
+  @override
+  Future<int> accountSetup({
+    required String uri,
+    required String username,
+    required String password,
+  }) async {
+    await initialize();
+    return rust_api.accountSetup(
+      uri: uri,
+      username: username,
+      password: password,
+    );
+  }
+
+  @override
+  Stream<CallInfo> registerCallStream() async* {
+    await initialize();
+    yield* rust_api.registerCallStream();
+  }
+
+  @override
+  Stream<AccountInfo> registerAccountStream() async* {
+    await initialize();
+    yield* rust_api.registerAccountStream();
+  }
+
+  @override
+  Future<void> markCallAlive({required int callId}) async {
+    await initialize();
+    await rust_api.markCallAlive(callId: callId);
+  }
+
+  @override
+  Future<int> makeCall({
+    required String phoneNumber,
+    required String domain,
+  }) async {
+    await initialize();
+    return rust_api.makeCall(phoneNumber: phoneNumber, domain: domain);
+  }
+
+  @override
+  Future<void> hangupCall({required int callId}) async {
+    await initialize();
+    await rust_api.hangupCall(callId: callId);
+  }
+
+  @override
+  Future<int> destroyPjsua() async {
+    await initialize();
+    return rust_api.destroyPjsua();
+  }
+}

--- a/lib/src/sip_api_native.dart
+++ b/lib/src/sip_api_native.dart
@@ -31,12 +31,14 @@ class NativeSipApi implements SipApi {
     required int localPort,
     required OnIncommingCall incomingCallStrategy,
     required String stunSrv,
+    LogLevel logLevel = .warning,
   }) async {
     await initialize();
     return rust_api.initPjsua(
       localPort: localPort,
       incomingCallStrategy: incomingCallStrategy,
       stunSrv: stunSrv,
+      logLevel: logLevel,
     );
   }
 

--- a/lib/src/sip_api_web.dart
+++ b/lib/src/sip_api_web.dart
@@ -1,0 +1,48 @@
+import '../rust/core/dart_types.dart';
+import '../rust/core/types.dart';
+import 'sip_api_interface.dart';
+
+SipApi createSipApi() => WebSipApi();
+
+class WebSipApi implements SipApi {
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  void dispose() {}
+
+  @override
+  Future<int> initPjsua({
+    required int localPort,
+    required OnIncommingCall incomingCallStrategy,
+    required String stunSrv,
+  }) async => 0;
+
+  @override
+  Future<int> accountSetup({
+    required String uri,
+    required String username,
+    required String password,
+  }) async => 0;
+
+  @override
+  Stream<CallInfo> registerCallStream() => const Stream.empty();
+
+  @override
+  Stream<AccountInfo> registerAccountStream() => const Stream.empty();
+
+  @override
+  Future<void> markCallAlive({required int callId}) async {}
+
+  @override
+  Future<int> makeCall({
+    required String phoneNumber,
+    required String domain,
+  }) async => 0;
+
+  @override
+  Future<void> hangupCall({required int callId}) async {}
+
+  @override
+  Future<int> destroyPjsua() async => 0;
+}

--- a/lib/src/sip_api_web.dart
+++ b/lib/src/sip_api_web.dart
@@ -35,10 +35,7 @@ class WebSipApi implements SipApi {
   Future<void> markCallAlive({required int callId}) async {}
 
   @override
-  Future<int> makeCall({
-    required String phoneNumber,
-    required String domain,
-  }) async => 0;
+  Future<int> makeCall({required String phoneNumber, required String domain}) async => 0;
 
   @override
   Future<void> hangupCall({required int callId}) async {}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -130,7 +130,7 @@ packages:
     source: hosted
     version: "1.1.2"
   code_assets:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: code_assets
       sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,10 +133,10 @@ packages:
     dependency: "direct main"
     description:
       name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
@@ -281,10 +281,10 @@ packages:
     dependency: "direct main"
     description:
       name: hooks
-      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -366,10 +366,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -382,10 +382,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -398,10 +398,10 @@ packages:
     dependency: "direct main"
     description:
       name: native_toolchain_rust
-      sha256: e53ef1025e2c190333ec61f638513c890c1becf11222e27b115b03bac369c6be
+      sha256: faa57d2258a3b0fd2a634054f54e4496c9fcbd971977e7d2b7e6916d56892857
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4+0"
   package_config:
     dependency: transitive
     description:
@@ -579,10 +579,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.11"
   toml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,13 +13,15 @@ topics:
 platforms:
   linux:
   windows:
-  android:  
+  android:
+  web:
 
 
 environment:
   sdk: ^3.10.0
 
 dependencies:
+  code_assets: ^1.0.0
   flutter:
     sdk: flutter
   flutter_rust_bridge: ^2.11.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,13 +21,13 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  code_assets: ^1.0.0
   flutter:
     sdk: flutter
   flutter_rust_bridge: ^2.11.1
   freezed_annotation: ^3.1.0
-  hooks: ^1.0.3
-  native_toolchain_rust: ^1.0.3
+  native_toolchain_rust: ^1.0.4
+  code_assets: ^1.2.1
+  hooks: ^2.0.2
   rxdart: ^0.28.0
 
 dev_dependencies:

--- a/rust/src/api/simple.rs
+++ b/rust/src/api/simple.rs
@@ -3,7 +3,7 @@
 use flutter_rust_bridge::frb;
 
 use crate::core::{
-    helpers::*, init_logger, managers::{AccountManager, CallManager}, pj_worker::get_pjsip_worker, types::{DartAccountStream, DartCallStream, OnIncommingCall, PJSUAError}
+    helpers::*, init_logger, managers::{AccountManager, CallManager}, pj_worker::get_pjsip_worker, types::{DartAccountStream, DartCallStream, LogLevel, OnIncommingCall, PJSUAError}
 };
 
 #[frb(init)]
@@ -15,9 +15,10 @@ pub fn init_pjsua(
     local_port: u32,
     incoming_call_strategy: OnIncommingCall,
     stun_srv: String,
+    log_level: LogLevel,
 ) -> Result<i8, PJSUAError> {
     // initialize pjsua
-    initialize_pjsua(incoming_call_strategy, local_port, stun_srv).map(|result| {
+    initialize_pjsua(incoming_call_strategy, local_port, stun_srv, log_level).map(|result| {
         // Start SIP alive tester task to check alive flag periodically as destroy management
         std::thread::spawn(|| crate::core::managers::call_alive_tester_task());
 

--- a/rust/src/core/helpers.rs
+++ b/rust/src/core/helpers.rs
@@ -10,7 +10,7 @@ use std::mem::MaybeUninit;
 use log::debug;
 
 use crate::{
-    core::types::{OnIncommingCall, PJSUAError, TransportMode},
+    core::types::{LogLevel, OnIncommingCall, PJSUAError, TransportMode},
     utils::{error_exit, make_pj_str_t},
 };
 
@@ -48,10 +48,11 @@ pub fn initialize_pjsua(
     incommingCallBehaviour: OnIncommingCall,
     port: u32,
     stun_srv: String,
+    log_level: LogLevel,
 ) -> Result<i8, PJSUAError> {
     debug!("initializing PJSIP");
     // INIT
-    init(incommingCallBehaviour, stun_srv)?;
+    init(incommingCallBehaviour, stun_srv, log_level)?;
 
     // ADD UDP TRANSPORT
     add_transport(port, TransportMode::UDP)?;
@@ -63,7 +64,7 @@ pub fn initialize_pjsua(
     Ok(0)
 }
 
-pub fn init(incomming_call_behaviour: OnIncommingCall, stun_srv: String) -> Result<i8, PJSUAError> {
+pub fn init(incomming_call_behaviour: OnIncommingCall, stun_srv: String, log_level: LogLevel) -> Result<i8, PJSUAError> {
     // Create PJSUA instance
     let status = unsafe { pj_sys::pjsua_create() };
     if status != pj_sys::pj_constants__PJ_SUCCESS as i32 {
@@ -93,7 +94,7 @@ pub fn init(incomming_call_behaviour: OnIncommingCall, stun_srv: String) -> Resu
     let mut log_cfg = MaybeUninit::<pj_sys::pjsua_logging_config>::zeroed();
     unsafe { pj_sys::pjsua_logging_config_default(log_cfg.as_mut_ptr()); }
     let log_cfg_ref = unsafe { &mut *log_cfg.as_mut_ptr() };
-    log_cfg_ref.console_level = 7;
+    log_cfg_ref.console_level = log_level.as_pj_level();
 
     // pjsua_media_config
     let mut media_cfg = MaybeUninit::<pj_sys::pjsua_media_config>::zeroed();

--- a/rust/src/core/types.rs
+++ b/rust/src/core/types.rs
@@ -38,6 +38,29 @@ pub enum TransportMode {
 }
 
 #[derive(Debug)]
+pub enum LogLevel {
+    /// Errors only
+    Error,
+    /// Errors and warnings
+    Warning,
+    /// Informational (registration, call setup, etc.)
+    Info,
+    /// Verbose debug output
+    Debug,
+}
+
+impl LogLevel {
+    pub fn as_pj_level(&self) -> u32 {
+        match self {
+            LogLevel::Error => 1,
+            LogLevel::Warning => 2,
+            LogLevel::Info => 3,
+            LogLevel::Debug => 7,
+        }
+    }
+}
+
+#[derive(Debug)]
 pub enum OnIncommingCall {
     AutoAnswer,
     Ignore

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -206,6 +206,7 @@ fn wire__crate__api__simple__init_pjsua_impl(
             let api_incoming_call_strategy =
                 <crate::core::types::OnIncommingCall>::sse_decode(&mut deserializer);
             let api_stun_srv = <String>::sse_decode(&mut deserializer);
+            let api_log_level = <crate::core::types::LogLevel>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, crate::core::types::PJSUAError>((move || {
@@ -213,6 +214,7 @@ fn wire__crate__api__simple__init_pjsua_impl(
                         api_local_port,
                         api_incoming_call_strategy,
                         api_stun_srv,
+                        api_log_level,
                     )?;
                     Ok(output_ok)
                 })())
@@ -500,6 +502,20 @@ impl SseDecode for Vec<u8> {
     }
 }
 
+impl SseDecode for crate::core::types::LogLevel {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => crate::core::types::LogLevel::Error,
+            1 => crate::core::types::LogLevel::Warning,
+            2 => crate::core::types::LogLevel::Info,
+            3 => crate::core::types::LogLevel::Debug,
+            _ => unreachable!("Invalid variant for LogLevel: {}", inner),
+        };
+    }
+}
+
 impl SseDecode for crate::core::types::OnIncommingCall {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -710,6 +726,26 @@ impl flutter_rust_bridge::IntoIntoDart<crate::core::dart_types::CallState>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::core::types::LogLevel {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            Self::Error => 0.into_dart(),
+            Self::Warning => 1.into_dart(),
+            Self::Info => 2.into_dart(),
+            Self::Debug => 3.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::core::types::LogLevel {}
+impl flutter_rust_bridge::IntoIntoDart<crate::core::types::LogLevel>
+    for crate::core::types::LogLevel
+{
+    fn into_into_dart(self) -> crate::core::types::LogLevel {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::core::types::OnIncommingCall {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
@@ -894,6 +930,24 @@ impl SseEncode for Vec<u8> {
         for item in self {
             <u8>::sse_encode(item, serializer);
         }
+    }
+}
+
+impl SseEncode for crate::core::types::LogLevel {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                crate::core::types::LogLevel::Error => 0,
+                crate::core::types::LogLevel::Warning => 1,
+                crate::core::types::LogLevel::Info => 2,
+                crate::core::types::LogLevel::Debug => 3,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
     }
 }
 


### PR DESCRIPTION
Introduced an abstraction layer for the SIP API to allow the package to build for web. Since PJSIP cannot be compiled for web, the web implementation provides no-op methods, ensuring compatibility while disabling actual functionality in browser environments.

also update deps and reducing logs noise by config  (fixes #20)
