### PR TITLE
Bundle libc++_shared

### DIFF
--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
@@ -13,10 +12,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {
@@ -36,6 +31,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -185,7 +185,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.2"
+    version: "1.1.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -78,5 +78,30 @@ void main(List<String> args) async {
         _pkgConfigSysrootAarch64EnvVar: pkgConfigSysrootDir,
       },
     ).run(input: input, output: output);
+
+    final codeConfig = input.config.code;
+    if (codeConfig.targetOS == OS.android) {
+      final ndkArchDir = switch (codeConfig.targetArchitecture) {
+        Architecture.arm64 => 'aarch64-linux-android',
+        Architecture.arm => 'arm-linux-androideabi',
+        Architecture.x64 => 'x86_64-linux-android',
+        Architecture.ia32 => 'i686-linux-android',
+        Architecture.riscv64 => 'riscv64-linux-android',
+        _ => null,
+      };
+
+      if (ndkArchDir != null) {
+        output.assets.code.add(
+          CodeAsset(
+            package: input.packageName,
+            name: 'c++_shared',
+            linkMode: DynamicLoadingBundled(),
+            file: Uri.file(
+              '$pkgConfigSysrootDir/usr/lib/$ndkArchDir/libc++_shared.so',
+            ),
+          ),
+        );
+      }
+    }
   });
 }


### PR DESCRIPTION
- Replace deprecated `kotlinOptions` with `kotlin.compilerOptions`
- Add `libc++_shared.so` to code assets for Android targets in build script